### PR TITLE
RSS Feed Fixes

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,6 +19,7 @@ permalink: /:title
 paginate: 8
 paginate_path: /page:num/
 source: .
+excerpt_separator: "<!-- excerpt end -->"
 
 # Default values
 defaults:

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,6 +1,6 @@
 <footer class="footer">
   <div class="footer-links">
-    <a href="{{ 'feed.xml' | relative_url }}">
+    <a href="{{ 'feed.xml' | absolute_url }}">
       <svg class="svg-icon orange"><use xlink:href="{{ 'img/social-icons.svg#rss' | relative_url }}"></use></svg><span>RSS</span>
     </a>&nbsp;&nbsp;&nbsp;&nbsp;
     <a href="https://eepurl.com/gpRedv">Subscribe</a>&nbsp;&nbsp;&nbsp;&nbsp;

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -23,6 +23,6 @@
   <link href='https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700,900,400italic%7CSignika:700,300,400,600' rel='stylesheet' type='text/css'>
 
   <!-- RSS -->
-  <link href="/atom.xml" type="application/atom+xml" rel="alternate" title="ATOM Feed" />
+  <link href="/feed.xml" type="application/rss+xml" rel="alternate" title="RSS 2.0 Feed" />
 
 </head>

--- a/_plugins/range-excerpt.rb
+++ b/_plugins/range-excerpt.rb
@@ -1,0 +1,11 @@
+require 'jekyll'
+
+module Jekyll
+    class Excerpt
+        alias_method :original_extract_excerpt, :extract_excerpt
+
+        def extract_excerpt(doc_content)
+            original_extract_excerpt(doc_content.split('<!-- excerpt start -->').last)
+        end
+    end
+end

--- a/feed.xml
+++ b/feed.xml
@@ -17,6 +17,12 @@ layout: null
             <link>{{ post.url | absolute_url | xml_escape }}</link>
             <description>
                 {{ post.excerpt | xml_escape }}
+                {% capture continue_reading %}
+                <p>
+                <a href="{{ post.url | absolute_url | xml_escape }}"><strong>Continue reading…</strong></a>
+                <p>
+                {% endcapture %}
+                {{ continue_reading | xml_escape }}
             </description>
             <guid>{{ post.url | absolute_url | xml_escape }}</guid>
             <pubDate>{{ post.date | date_to_xmlschema }}</pubDate>

--- a/feed.xml
+++ b/feed.xml
@@ -18,7 +18,7 @@ layout: null
                 {{ post.url | prepend: site.url }}
             </link>
             <description>
-                {{ post.content | split:'<!-- excerpt end -->' | first | split:'<!-- excerpt start -->' | last | escape }}
+                {{ post.excerpt | xml_escape }}
             </description>
             {% assign author = site.data.authors[post.author] %}
             {% if author %}

--- a/feed.xml
+++ b/feed.xml
@@ -6,20 +6,20 @@ layout: null
 <rss version="2.0">
 
     <channel>
-        <title>{{ site.title }}</title>
-        <link>{{ site.url }}</link>
-        <description>{{ site.description }}</description>
-        <pubDate>{{ site.posts[0].date | date_to_rfc822 }}</pubDate>
-        <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
+        <title>{{ site.title | xml_escape }}</title>
+        <link>{{ site.url | xml_escape }}</link>
+        <description>{{ site.description | xml_escape }}</description>
+        <pubDate>{{ site.posts[0].date | date_to_xmlschema }}</pubDate>
+        <lastBuildDate>{{ site.time | date_to_xmlschema }}</lastBuildDate>
         {% for post in site.posts %}
         <item>
-            <title>{{ post.title }}</title>
-            <link>
-                {{ post.url | prepend: site.url }}
-            </link>
+            <title>{{ post.title | xml_escape }}</title>
+            <link>{{ post.url | absolute_url | xml_escape }}</link>
             <description>
                 {{ post.excerpt | xml_escape }}
             </description>
+            <guid>{{ post.url | absolute_url | xml_escape }}</guid>
+            <pubDate>{{ post.date | date_to_xmlschema }}</pubDate>
             {% assign author = site.data.authors[post.author] %}
             {% if author %}
                 <author>
@@ -27,10 +27,6 @@ layout: null
                     <uri>{{ author.web | xml_escape }}</uri>
                 </author>
             {% endif %}
-                <pubDate>{{ post.date | date_to_rfc822 }}</pubDate>
-            <guid>
-                {{ post.url | prepend: site.url }}
-            </guid>
         </item>
         {% endfor %}
     </channel>

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@ layout: default
             <span>by <a href="{{ author.web }}">{{ author.name }}</a></span>
             {% endif %}
         </div>
-        <p>{{ post.content | split:'<!-- excerpt end -->' | first | split:'<!-- excerpt start -->' | last }}</p>
+        <p>{{ post.excerpt }}</p>
     </li>
 
     {% endfor %}

--- a/readme.md
+++ b/readme.md
@@ -26,7 +26,7 @@ see your drafts.
 
 We recommend:
 ```terminal
-$ jekyll serve -b / -D
+$ bundle install jekyll serve -b / -D
 ```
 
 ## Acknowledgements


### PR DESCRIPTION
Adressed Issues:
- The RSS Icon in the browser wouldn't allow me to subscribe (linked to non-existent ATOM feed).
- Posts only showed excerpts (seems intentional) without clear communication that there would be more content.
- I couldn't click the title of a post, because the URL would contain leading and trailing semantic whitespace -> invalid URL (`%20%20%20%20%20%20https://...`).
- I couldn't copy the RSS URL easily since it was a relative URL instead of an absolute URL.
- Many fields weren't escaped properly.

Changes:
- Move custom excerpt logic into a plugin.
- Remove semantic whitespace.
- Escape all the fields.
- Fix `<link>`