### PR TITLE
Tweak styling

### DIFF
--- a/404.md
+++ b/404.md
@@ -2,6 +2,7 @@
 layout: default
 title: 404 - Page not found
 ---
-404 - Page not found
-====================
+
+## 404 - Page not found
+
 Sorry, we couldn’t find the requested URL. You can try again by going [back to the homepage]({{ site.baseurl }}).

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -20,7 +20,7 @@
 
   <!-- CSS & fonts -->
   <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl | replace: '//', '/' }}">
-  <link href='https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,700,900,400italic%7CSignika:700,300,400,600' rel='stylesheet' type='text/css'>
+  <link href='https://fonts.googleapis.com/css?family=Source+Code+Pro:400%7CSource+Sans+Pro:300,400,700,900,400italic%7CSignika:700,300,400,600' rel='stylesheet' type='text/css'>
 
   <!-- RSS -->
   <link href="/feed.xml" type="application/rss+xml" rel="alternate" title="RSS 2.0 Feed" />

--- a/_posts/2019-07-09-get-the-most-out-of-the-linker-map-file.md
+++ b/_posts/2019-07-09-get-the-most-out-of-the-linker-map-file.md
@@ -377,10 +377,7 @@ Feel free to share your story with any interesting usage of the map files.
 
 ## Sources
 
-[https://www.embeddedrelated.com/showarticle/900.php](https://www.embeddedrelated.com/showarticle/900.php)
-
-[https://stackoverflow.com/questions/755783/whats-the-use-of-map-files-the-linker-produces](https://stackoverflow.com/questions/755783/whats-the-use-of-map-files-the-linker-produces)
-
-[https://sourceware.org/binutils/docs/ld/Options.html#index-_002d_002dprint_002dmap](https://sourceware.org/binutils/docs/ld/Options.html#index-_002d_002dprint_002dmap)
-
-[https://www.oreilly.com/library/view/programming-embedded-systems/0596009836/ch04.html](https://www.oreilly.com/library/view/programming-embedded-systems/0596009836/ch04.html)
+- [https://www.embeddedrelated.com/showarticle/900.php](https://www.embeddedrelated.com/showarticle/900.php)
+- [https://stackoverflow.com/questions/755783/whats-the-use-of-map-files-the-linker-produces](https://stackoverflow.com/questions/755783/whats-the-use-of-map-files-the-linker-produces)
+- [https://sourceware.org/binutils/docs/ld/Options.html#index-_002d_002dprint_002dmap](https://sourceware.org/binutils/docs/ld/Options.html#index-_002d_002dprint_002dmap)
+- [https://www.oreilly.com/library/view/programming-embedded-systems/0596009836/ch04.html](https://www.oreilly.com/library/view/programming-embedded-systems/0596009836/ch04.html)

--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -16,12 +16,14 @@ html, body, h1, h2, h3, h4, h5, h6, p, ul, ol, li, img {
   border: 0;
 }
 
+$baseline-height: 2rem;
+
 /*- Base color -*/
 
 $main-color: #141845;
 $background-color: #FDFDFD;
 $text-color: #222222;
-$link-color: #1390CF;
+$link-color: $main-color;
 
 // Dark theme (not used)
 $main-color-dark: #FDFDFD;
@@ -32,21 +34,29 @@ $text-color-dark: #FDFDFD;
 
 html {
 	background-color: $background-color;
-	font-size: 16px;
 	@media (min-width: 940px) {
 		font-size: 18px;
 	}
-	line-height: 1.5;
+	line-height: $baseline-height;
 	color: $text-color;
 }
 
 /*- Link -*/
 a {
-	color: $main-color;
+	color: $link-color;
 	text-decoration: none;
 	font-weight: 700;
 	&:hover,
 	&:focus {
 		color: darken($link-color, 5%);
+	}
+}
+
+article .content a {
+	font-weight: normal;
+	border-bottom: 1px solid rgba($link-color, 0.35);
+
+	&:hover, &:focus {
+		border-bottom-color: $link-color;
 	}
 }

--- a/_sass/custom.scss
+++ b/_sass/custom.scss
@@ -33,6 +33,13 @@ $linkedin-color: #0077B5;
     margin: 23px auto;
     background-color: lighten($text-color, 70%);
   }
+
+  ul, ol {
+    ul, ol {
+      margin-left: 4ex;
+      margin-bottom: 0;
+    }
+  }
 }
 
 div.author {

--- a/_sass/layout.scss
+++ b/_sass/layout.scss
@@ -134,6 +134,11 @@ html, body {
   img {
   	display: block;
   }
+  h1 {
+    font-size: 2.5rem;
+    line-height: 3rem;
+    padding: 0.25rem 0;
+  }
   #logo {
   	max-height: 66px;
     margin-top: 6px;
@@ -214,16 +219,6 @@ img[title="Emerald"] {
 
 code {
   color: lighten($text-color, 35%);
-}
-
-/* Set the vertical rhythm (and padding-left) for lists inside post content */
-
-.content ul, .content ol {
-  line-height: 1.5em; /* 24px/16px */
-  padding-left: 1.5em;
-  @media (min-width: 940px) {
-    line-height: 1.33334em; /* 24px/18px */
-  }
 }
 
 /* Pages */

--- a/_sass/typography.scss
+++ b/_sass/typography.scss
@@ -5,37 +5,55 @@
 
 body {
 	font-family: 'Source Sans Pro', sans-serif;
-	letter-spacing: 0.01em;
+	// letter-spacing: 0.01em;
+}
+
+pre, code {
+	font-family: 'Source Code Pro', monospace;
 }
 
 pre {
-    font-size: 14px;
+	font-size: 0.9rem;
+	line-height: 1.2rem;
+}
+
+p code {
+	margin: 0 0.25ex;
+	font-size: 90%;
 }
 
 /*- Typography for medium and small screen, based on 16px font-size -*/
 
 p, ul, ol {
-	font-size: 1em; /* 16px */
-	line-height: 1.5em; /* 24px/16px */
-	margin-bottom: 1.5em; /* 24px/16px */
+	margin-bottom: 0.5 * $baseline-height;
 }
 
 h1 {
-	font-size: 2.25em; /* 36px/16px */
-	line-height: 1.3333em; /* 48px/36px */
-	padding: 0.33335em 0; /* 12px/36px * 2 (Use padding instead of margin to maintain proximity with paragraph) */
+	font-size: 3rem;
+	line-height: 4.5rem;
+
+	article .content & {
+		padding-bottom: $baseline-height;
+	}
 }
 
 h2 {
-	font-size: 1.5em; /* 24px/16px */
-	line-height: 1em; /* 24px/24px */
-	padding: 1em 0 0 0; /* 12px/24px * 2, only top (Use padding instead of margin to maintain proximity with paragwithph) */
+	font-size: 1.5rem;
+	line-height: 3rem;
+	article .content & {
+		padding-bottom: 0.5 * $baseline-height;
+	}
 }
 
 h3, h4, h5, h6 {
-	font-size: 1.125em; /* 18px/16px */
-	line-height: 1.3334em; /* 24px/18px */
-	padding: 0.66667em 0; /* 12px/18px * 2 (Use padding instead of margin to maintain proximity with paragraph) */
+	font-size: 1.25rem;
+	line-height: 2rem;
+
+	article .content & {
+		// Using padding to avoid collapse with previous element margin
+		padding-top: 0.25 * $baseline-height;
+		margin-bottom: 0.25 * $baseline-height;
+	}
 }
 
 blockquote {
@@ -50,54 +68,4 @@ blockquote {
 	p, ul, ol {
 		padding: 1.5em 0; /* 24px/18px */
 	}
-}
-
-/*- Typography for big screen, based on 18px font-size -*/
-
-@media (min-width: 940px) { //Breakpoint set to 940px
-
-p, ul, ol {
-	font-size: 1em; /* 18px */
-	line-height: 1.3334em; /* 24px/18px */
-	margin-bottom: 1.3334em; /* 24px/18px */
-}
-
-h1 {
-	font-size: 2.6667em; /* 48px/18px */
-	line-height: 1em; /* 48px/48px */
-	padding: 0.25em 0; /* 12px/48px * 2 (Use padding instead of margin to maintain proximity with paragraph) */
-}
-
-h2 {
-	font-size: 2em; /* 36px/18px */
-	line-height: 1.3334em; /* 48px/36px */
-	padding: 0.66667em 0 0 0; /* 12px/36px * 2, pnly top (Use padding instead of margin to maintain proximity with paragraph) */
-}
-
-h3 {
-	font-size: 1.3334em; /* 24px/18px */
-	line-height: 1em; /* 24px/24px */
-	padding: 0.5em 0; /* 12px/24px * 2 (Use padding instead of margin to maintain proximity with paragraph) */
-}
-
-h4, h5, h6 {
-	font-size: 1.1em;
-	line-height: 0.9em;
-	padding: 0.5em 0;
-}
-
-blockquote {
-	font-style: italic;
-	margin: 1.3334em; /* 24px/18px */
-	-webkit-border-radius: 4px;
-	   -moz-border-radius: 4px;
-	    -ms-border-radius: 4px;
-          border-radius: 4px;
-	background-color: darken($background-color, 5%);
-	padding: 0 1.33334em; /* 24px/18px */
-	p, ul, ol {
-		padding: 1.33334em 0; /* 24px/18px */
-	}
-}
-
 }


### PR DESCRIPTION
Something I had in my stash:

- Revert link color, unbold links, underline links. Tends improve accessibility (since convention) and also is less distracting while reading an article.
- Use a monospaced font from Google Fonts for code.
- Tweaked everything to follow a vertical grid (`0.25rem` increments) for a better visual rhythm. Also increased line-height for regular paragraphs to provide more negative whitespace (more airy).

![out3](https://user-images.githubusercontent.com/56807/61823763-b8132f00-ae5c-11e9-828a-aa638fadedd8.gif)
