### PR TITLE
Remove Post list margin on left

### DIFF
--- a/_sass/layout.scss
+++ b/_sass/layout.scss
@@ -164,9 +164,14 @@ html, body {
 /* Posts */
 
 #posts {
+  // In topography, we've set li/ul to have margin-left so that
+  // lists are indented properly. With posts, we use a ul
+  // so we have to undo that change.
   li {
     list-style-type: none;
+    margin-left: 0;
   }
+  margin-left: 0;
 }
 
 #post-page {


### PR DESCRIPTION
In a previous change, we added `margin-left: 1.5em` on all `li,ul`
elements. Unfortunately, the post lists use `ul` so this master change
applied to every listing of posts too and now the website looks worse on
mobile.

Here we add special formatting for post lists to remove that global (and
generally sensible) margin