### PR TITLE
Show an error if IMPL is invalid

### DIFF
--- a/example/debugging-asserts/Makefile
+++ b/example/debugging-asserts/Makefile
@@ -42,6 +42,8 @@ else ifeq ($(IMPL),ASSERT4)
 else ifeq ($(IMPL),ASSERT5)
   SRC_FILES += \
     $(PROJECT_SRC_DIR)/impls/assert5.c
+else
+  $(error IMPL is not set to a valid assert implementation)
 endif
 
 


### PR DESCRIPTION
Before:
```
$ make
...
Linking library
ld: interrupt/example/debugging-asserts/build/main.o: in function `prv_main_path_A':
interrupt/example/debugging-asserts/main.c:19: undefined reference to `assert_path_A'
ld: interrupt/example/debugging-asserts/main.c:21: undefined reference to `assert_path_B'
collect2: error: ld returned 1 exit status
make: *** [interrupt/example/debugging-asserts/build/nrf52.elf] Error 1
```

After:
```
$ make
Makefile:46: *** IMPL is not set to a valid assert implementation.  Stop.
```