### PR TITLE
Make all links to the img directory root-relative

### DIFF
--- a/_posts/2019-05-21-gdb-for-firmware-1.md
+++ b/_posts/2019-05-21-gdb-for-firmware-1.md
@@ -11,13 +11,13 @@ Not convinced?
 
 I'll leave you with a few figures taken from the 2017 Embedded/EETimes **Embedded Markets Study** survey which showcase the significance of debugging in the professional life of a firmware developer.
 
-![](img/gdb-tips-and-tricks/Job-Functions.png)
+![](/img/gdb-tips-and-tricks/Job-Functions.png)
 <br>
 
-![](img/gdb-tips-and-tricks/Design-time.png)
+![](/img/gdb-tips-and-tricks/Design-time.png)
 <br>
 
-![](img/gdb-tips-and-tricks/Tool-improvement.png)
+![](/img/gdb-tips-and-tricks/Tool-improvement.png)
 <br>
 
 Let's face it..
@@ -85,7 +85,7 @@ Installation of the nRF5 SDK is straightforward. All you need to do is download 
 Once you extract it, you should see the following directory structure:
 
 
-![](img/gdb-tips-and-tricks/nRF5_SDK_folder.png)
+![](/img/gdb-tips-and-tricks/nRF5_SDK_folder.png)
 
 
 #### 2. nRF5 Command Line Tools
@@ -96,14 +96,14 @@ Next, we need to install the nRF5 Command Line Tools. These include **nrfjprog**
 First, make sure you select the appropriate operating system (macOS in our case).
 
 
-![](img/gdb-tips-and-tricks/nRF5_Command_Line_Tools.png)
+![](/img/gdb-tips-and-tricks/nRF5_Command_Line_Tools.png)
 <br/>
 
 Select the latest version, and then click "Download File".
 
 This is what the contents of the folder should look like:
 
-![](img/gdb-tips-and-tricks/nRF5_Command_Line_Tools_Folder.png)
+![](/img/gdb-tips-and-tricks/nRF5_Command_Line_Tools_Folder.png)
 
 #### 3. SEGGER J-Link
 The SEGGER J-Link software is needed for the GDB Server interface to the nRF52 chipset on the development kit.
@@ -113,13 +113,13 @@ So let's go ahead and download the software.
 [**Link to download SEGGER J-Link Software**](https://www.segger.com/downloads/jlink/#J-LinkSoftwareAndDocumentationPack)
 
 
-![](img/gdb-tips-and-tricks/J-Link_Software_Download.png)
+![](/img/gdb-tips-and-tricks/J-Link_Software_Download.png)
 <br/>
 
 This download (for macOS) is a .**pkg** installer file. Once you download it, simply double-click it and go through the installation process.
 
 
-![](img/gdb-tips-and-tricks/J-Link_Installation.png)
+![](/img/gdb-tips-and-tricks/J-Link_Installation.png)
 
 
 #### 4. GNU Arm Embedded Toolchain
@@ -128,13 +128,13 @@ The next software package that we need to install is the GNU Arm Embedded Toolch
 **[Direct link to download the GNU Arm Embedded Toolchain (version 7-2017-q4-major)](https://developer.arm.com/-/media/Files/downloads/gnu-rm/7-2017q4/gcc-arm-none-eabi-7-2017-q4-major-mac.tar.bz2?revision=7f453378-b2c3-4c0d-8eab-e7d5db8ea32e?product=GNU%20Arm%20Embedded%20Toolchain,64-bit,,Mac%20OS%20X,7-2017-q4-major)**
 
 
-![](img/gdb-tips-and-tricks/GNU_Arm_Embedded_Download.png)
+![](/img/gdb-tips-and-tricks/GNU_Arm_Embedded_Download.png)
 <br/>
 
 After you download the package, simply extract it to your folder of choice.
 
 
-![](img/gdb-tips-and-tricks/GNU_Arm_Download_Folder.png)
+![](/img/gdb-tips-and-tricks/GNU_Arm_Download_Folder.png)
 
 
 #### 5. Serial Terminal Program
@@ -192,7 +192,7 @@ In our tutorial, we'll be using the UART example included as part of the nRF5 SD
 
 You'll notice there are many subfolders in that folder. We are mostly interested in the following highlighted folder in the screenshot:
 
-![](img/gdb-tips-and-tricks/uart_folder.png)
+![](/img/gdb-tips-and-tricks/uart_folder.png)
 <br/>
 
 Before we build the example, let's make sure we have the right compiler flags for debugging. This is necessary to include debugging symbols that help GDB present useful debugging information to the user. 
@@ -244,7 +244,7 @@ $ make
 The output should look something like this:
 
 
-![](img/gdb-tips-and-tricks/Make_Output.png)
+![](/img/gdb-tips-and-tricks/Make_Output.png)
 
 
 ### 2. Hardware Setup
@@ -258,7 +258,7 @@ Here are the steps to accomplish this:
 	- **SW9** (nRF power source) set to "VDD"
 	- **Power** set to "ON"
 
-	![](img/gdb-tips-and-tricks/nRF52840_dev_kit.png)
+	![](/img/gdb-tips-and-tricks/nRF52840_dev_kit.png)
 	
 - Erase the development kit by running the following command:
 
@@ -289,13 +289,13 @@ There are three parts to get this working:
 - Make sure the serial port settings are correct (listed at [this link](https://infocenter.nordicsemi.com/topic/com.nordic.infocenter.sdk5.v15.3.0/uart_example.html)):
  
 	
-	![](img/gdb-tips-and-tricks/CoolTerm_Settings.png)
+	![](/img/gdb-tips-and-tricks/CoolTerm_Settings.png)
 	
 	Now, hit **OK**. 
 
 - Finally, connect to the serial port by clicking the "Connect" button:
 	
-	![](img/gdb-tips-and-tricks/CoolTerm_Connect.png)
+	![](/img/gdb-tips-and-tricks/CoolTerm_Connect.png)
 	
 	You may not see any output since the program probably started before you connected. To reset the development board, we can simply run the following command from the Terminal:
 	
@@ -306,7 +306,7 @@ There are three parts to get this working:
 	If all goes well, you should see the following printed in the Terminal window:
 	
 	
-	![](img/gdb-tips-and-tricks/CoolTerm_Output.png)
+	![](/img/gdb-tips-and-tricks/CoolTerm_Output.png)
 	
 
 ## Debugging the Program
@@ -331,7 +331,7 @@ There are a few steps to get this working.
 	
 	The output should look something like this:
 	
-	![](img/gdb-tips-and-tricks/GDB_Server_Run.png)
+	![](/img/gdb-tips-and-tricks/GDB_Server_Run.png)
 	
 	
 - **Running GDB**
@@ -345,7 +345,7 @@ There are a few steps to get this working.
 	```
 	
 	
-	![](img/gdb-tips-and-tricks/arm_gdb_run.png)
+	![](/img/gdb-tips-and-tricks/arm_gdb_run.png)
 	
 
 	Next, we want to tell GDB what output file is used for the program running on the development kit. We do so with the following command within the GDB console:
@@ -355,7 +355,7 @@ There are a few steps to get this working.
 	```
 
 	
-	![](img/gdb-tips-and-tricks/arm_gdb_file.png)
+	![](/img/gdb-tips-and-tricks/arm_gdb_file.png)
 	
 	
 - **Connecting GDB to the Remote Target**
@@ -367,7 +367,7 @@ There are a few steps to get this working.
 	```
 	
 	
-	![](img/gdb-tips-and-tricks/arm_gdb_target.png)
+	![](/img/gdb-tips-and-tricks/arm_gdb_target.png)
 	
 	
 	The GDB Server (which should be left running in another Terminal window) will show something like the following:
@@ -388,19 +388,19 @@ The first command you should be aware of is the **help** command. You can use **
 
 For example, let's run **help** for the "breakpoint" command:
 
-![](img/gdb-tips-and-tricks/gdb_help.png)
+![](/img/gdb-tips-and-tricks/gdb_help.png)
 
 #### Breakpoint
 The Breakpoint command is used to set a breakpoint at a location telling the debugger to halt the application when the program reaches that line of code. You can use the shortcut **b** instead of spelling out the full name, too.
 
-![](img/gdb-tips-and-tricks/gdb_breakpoint.png)
+![](/img/gdb-tips-and-tricks/gdb_breakpoint.png)
 
 
 #### Continue
 The **Continue** command is used to continue execution after a breakpoint was hit. You can simply use the shortcut **c** instead of spelling out the full word.
 
 
-![](img/gdb-tips-and-tricks/gdb_continue.png)
+![](/img/gdb-tips-and-tricks/gdb_continue.png)
 
 
 #### Breakpoints with Condition
@@ -410,7 +410,7 @@ This is where the **Breakpoint with condition** command comes in.
 
 In our example program, the code in **main.c** at **line 175** checks the character sent from the UART to see if it matches the `q` or `Q` character:
 
-![](img/gdb-tips-and-tricks/main_code_175.png)
+![](/img/gdb-tips-and-tricks/main_code_175.png)
 <br/>
 
 We can set a breakpoint that only stops the program if we receive a specific character (other than `q` or `Q`), for example: `s`.
@@ -423,7 +423,7 @@ Now, if we set this breakpoint, we can run the program as normal and then type t
 
 We'll see that the application halts only if that character is sent across the UART.
 
-![](img/gdb-tips-and-tricks/gdb_conditional_breakpoint_halt.png)
+![](/img/gdb-tips-and-tricks/gdb_conditional_breakpoint_halt.png)
 
 
 #### Backtrace
@@ -431,7 +431,7 @@ The Backtrace command is used to show the call stack of the program at the curre
 
 Here's what the output of **backtrace** looks like when adding the "full" option to show all the local variables as well:
 
-![](img/gdb-tips-and-tricks/gdb_bt_full.png)
+![](/img/gdb-tips-and-tricks/gdb_bt_full.png)
 
 If you want to make it look "pretty" with some basic formatting, you could use the following command:
 
@@ -441,20 +441,20 @@ If you want to make it look "pretty" with some basic formatting, you could use t
 
 Here's a screenshot showing the difference between the output with "pretty" being **on** or **off**:
 
-![](img/gdb-tips-and-tricks/gdb_pretty_bt_full.png)
+![](/img/gdb-tips-and-tricks/gdb_pretty_bt_full.png)
 
 #### Step
 The **Step** command is used to *step* through and execute your source code during debugging. It **will** step into any function in its path, however it **will not** step into functions that do not contain debugging information.
 
 For reference, here's our code again from main.c:
 
-![](img/gdb-tips-and-tricks/main_code_175.png)
+![](/img/gdb-tips-and-tricks/main_code_175.png)
 <br/>
 
 Let's take a look at how the Step command behaves after hitting the breakpoint at main.c:175 that we had set.
 
 
-![](img/gdb-tips-and-tricks/gdb_step.png)
+![](/img/gdb-tips-and-tricks/gdb_step.png)
 
  
 Notice that GDB stepped into the function **app_uart_get()** after reaching line 172.
@@ -465,7 +465,7 @@ The **List** command shows the source code for the current Program Counter (PC).
 Here's an example of using **List** after we hit our breakpoint at **main.c:175**.
 
 
-![](img/gdb-tips-and-tricks/gdb_list.png)
+![](/img/gdb-tips-and-tricks/gdb_list.png)
 
 
 #### Info
@@ -475,15 +475,15 @@ Here are some examples for uses of **Info**.
 
 - **Info locals**: shows information about all local variables.
 	
-	![](img/gdb-tips-and-tricks/gdb_info_locals.png)
+	![](/img/gdb-tips-and-tricks/gdb_info_locals.png)
 	
 - **Info variables**: shows information about all types of variables (local and global).
 	
-	![](img/gdb-tips-and-tricks/gdb_info_variables.png)
+	![](/img/gdb-tips-and-tricks/gdb_info_variables.png)
 	
 - **Info files**: shows information about all files being debugged. 
 	
-	![](img/gdb-tips-and-tricks/gdb_info_files.png)
+	![](/img/gdb-tips-and-tricks/gdb_info_files.png)
 
 #### Logging
 One useful feature within GDB is the ability to log all output to a text file. This makes it much easier to share the output of GDB with others, or to simply save the output for later reference.

--- a/_posts/2019-06-06-best-firmware-size-tools.md
+++ b/_posts/2019-06-06-best-firmware-size-tools.md
@@ -221,12 +221,12 @@ coworker at Pebble.
 Puncover will give you a full hierarchical view of both code size and static
 memory per module, file, and function. See the screenshot below:
 
-![](img/code-size-1/puncover-1.png)
+![](/img/code-size-1/puncover-1.png)
 
 It also shows you details for each function, including callers, callees, and
 disassembly.
 
-![](img/code-size-1/puncover-2.png)
+![](/img/code-size-1/puncover-2.png)
 
 Truly, it is a firmware analysis swiss army knife!
 

--- a/_posts/2019-07-16-fix-bugs-and-secure-firmware-with-the-mpu.md
+++ b/_posts/2019-07-16-fix-bugs-and-secure-firmware-with-the-mpu.md
@@ -52,14 +52,14 @@ The MPU is configured using just five registers! A great way to build an underst
 ### MPU Type Register
 
 `MPU_TYPE` - Address 0xE000ED90 register bit assignments:
-![](img/armv7m_mpu/mpu_type.png)
+![](/img/armv7m_mpu/mpu_type.png)
 
 This register is present regardless of whether or not the MPU was implemented on the _Cortex-M_ device being used. This is pretty nice because it allows us to dynamically determine at runtime or via a [GDB Python script](https://interrupt.memfault.com/blog/automate-debugging-with-gdb-python-api) whether or not an MPU is present and use it. The **only** field of interest here is `DREGION` which reveals the number of MPU regions which were implemented. A value of 0 for `DREGION` indicates the MPU was not implemented.
 
 ### MPU Control Register
 
 `MPU_CTRL` - Address 0xE000ED94 register bit assignments:
-![](img/armv7m_mpu/mpu_ctrl.png)
+![](/img/armv7m_mpu/mpu_ctrl.png)
 
 This register is how we actually enable the MPU. Until the `ENABLE` bit is set, the MPU configuration in other registers have no effect.
 
@@ -70,7 +70,7 @@ This register is how we actually enable the MPU. Until the `ENABLE` bit is set, 
 ### MPU Region Number Register
 
 `MPU_RNR` - Address 0xE000ED98 register bit assignments:
-![](img/armv7m_mpu/mpu_rnr.png)
+![](/img/armv7m_mpu/mpu_rnr.png)
 
 As we saw in the `MPU_TYPE` register above, the MPU is broken into a certain number of configurable-regions. The _M0+_, _M3_ & _M4_ can support up to 8 regions when the MPU is implemented and the M7 can support up to 16! The `REGION` field is used to select the active region we want to read or update. Once the region is selected, we can read or write `MPU_RBAR` & `MPU_RASR` to see the configuration and make changes.
 
@@ -81,7 +81,7 @@ As we saw in the `MPU_TYPE` register above, the MPU is broken into a certain num
 ### MPU Region Base Address Register
 
 `MPU_RBAR` Address 0xE000ED9C register bit assignments:
-![](img/armv7m_mpu/mpu_rbar.png)
+![](/img/armv7m_mpu/mpu_rbar.png)
 
 This register is used to control the starting address (aka the _base address_) that we want to cover with the region selected in `MPU_RNR`. For example, if we wanted to protect the address range starting at the beginning of a SRAM range (i.e `0x20000000`) using `REGION 0`, we would first set `MPU_RNR` to 0 and then set `MPU_RBAR` to `0x20000000`)
 
@@ -94,7 +94,7 @@ To reduce the number of writes needed to change the configuration, the `VALID` b
 ### MPU Region Attribute and Size Register
 
 `MPU_RASR` - Address 0xE000EDA0 register bit assignments:
-![](img/armv7m_mpu/mpu_rasr.png)
+![](/img/armv7m_mpu/mpu_rasr.png)
 
 This is the register where nearly all of the MPU configuration magic actually happens. The `ENABLE` bit controls whether or not the region is active (when the MPU itself has been enabled by setting the `ENABLE` bit in `MPU_CTRL`).
 
@@ -106,7 +106,7 @@ The configuration can be broken down into four main parts:
 
 This config is comprised of the `TEX` (_Type Extension Mask_), `C` (_Cacheable_), `B` (_Bufferable_), & `S` (_Shareable_) fields. More details about each memory attribute can be found in the _Summary of ARMv7 memory attributes_ of the [ARMv7-M reference manual](https://static.docs.arm.com/ddi0403/eb/DDI0403E_B_armv7m_arm.pdf). Typically, these settings do not matter much for a single core _Cortex-M_ implementation. I usually follow the recommendations in the table below from [here](http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0552a/BABDJJGF.html):
 
-![](img/armv7m_mpu/mpu_rasr_attr_rec.png)
+![](/img/armv7m_mpu/mpu_rasr_attr_rec.png)
 
 If you are using a more complex _Cortex-M_ setup (like a _Cortex-M7_ with a cache), the vendor data sheet may have a section with better recommendations.
 
@@ -115,7 +115,7 @@ If you are using a more complex _Cortex-M_ setup (like a _Cortex-M7_ with a cach
 #### 2. Access permissions & Execute Never encoding
 
 This part is comprised of the `AP` (_Access Permissions_) fields used to control the rules around how the region can be accessed:
-![](img/armv7m_mpu/mpu_rasr_ap.png)
+![](/img/armv7m_mpu/mpu_rasr_ap.png)
 
 There is also the `XN` (_Execute Never_) field, used to control whether or not the processor can fetch instructions from this region. If the `XN` bit is set, an instruction fetch from the region will cause a fault.
 
@@ -254,7 +254,7 @@ MemoryManagement_Handler () at ../../../main.c:20
 When a MemManage fault is hit there are a couple registers that are very helpful to look at.
 
 The first is the MemManage Status Register (`MMFSR`) - 0xE000ED28:
-![](img/armv7m_mpu/mpu_mmfsr.png)
+![](/img/armv7m_mpu/mpu_mmfsr.png)
 
 The second is the MemManage Fault Address Register (`MMFAR`) located at 0xE000ED34 which contains the address of the access which triggered the fault provided `MMFSR.MMARVALID` is set.
 

--- a/_posts/2019-07-30-bluetooth-low-energy-a-primer.md
+++ b/_posts/2019-07-30-bluetooth-low-energy-a-primer.md
@@ -75,7 +75,7 @@ Every technology has its own benefits and limitations, and BLE is no exception. 
 ## Bluetooth Low Energy Architecture
 Here’s a diagram showing the different levels of the architecture of BLE:
 
-![](img/ble-primer/ble_architecture.png)
+![](/img/ble-primer/ble_architecture.png)
 
 The good thing is that, as a developer looking to develop BLE applications, you won’t have to worry much about the layers below the Security Manager and Attribute Protocol. But lets at least cover the definitions of these layers:
 
@@ -116,7 +116,7 @@ Keep in mind that a single device may operate in multiple Roles at the same time
 ### Advertising & Scanning
 In the Advertising state a device sends out packets containing useful data for others to receive and process. The packets are sent at a fixed interval defined as the Advertising Interval. There are 40 RF channels in BLE, each separated by 2 MHz (center-to-center), as shown in the following figure. Three of these channels are called the Primary Advertising Channels, while the remaining 37 channels are used for Secondary Advertisements and for Data Packet transfer during a Connection.
 
-![](img/ble-primer/ble_channels.png)
+![](/img/ble-primer/ble_channels.png)
 
 Advertisements always start with Advertisement Packets sent on the 3 Primary Advertising Channels (or a subset of these Channels). This allows Centrals to find the Advertising device (Peripheral or Broadcaster) and parse its Advertising packets. The Central can then Initiate a Connection if the Advertiser allows it (Peripheral devices).
 
@@ -231,7 +231,7 @@ Installation of the nRF5 SDK is straightforward. All you need to do is download 
 
 Once you extract it, you should see the following directory structure:
 
-![](img/ble-primer/nRF5_SDK_folder.png)
+![](/img/ble-primer/nRF5_SDK_folder.png)
 
 #### 2. nRF5 Command Line Tools
 Next, we need to install the nRF5 Command Line Tools. These include **nrfjprog**, which is a tool for programming your nRF52 development kit via the Segger J-Link debugger and needed in our case for working from the command line.
@@ -240,14 +240,14 @@ Next, we need to install the nRF5 Command Line Tools. These include **nrfjprog**
 
 First, make sure you select the appropriate operating system (macOS in our case).
 
-![](img/ble-primer/nRF5_Command_Line_Tools.png)
+![](/img/ble-primer/nRF5_Command_Line_Tools.png)
 <br/>
 
 Select the latest version, and then click "Download File".
 
 This is what the contents of the folder should look like:
 
-![](img/ble-primer/nRF5_Command_Line_Tools_Folder.png)
+![](/img/ble-primer/nRF5_Command_Line_Tools_Folder.png)
 
 #### 3. SEGGER J-Link
 The SEGGER J-Link software is needed for the GDB Server interface to the nRF52 chipset on the development kit.
@@ -256,24 +256,24 @@ So let's go ahead and download the software.
 
 [**Link to download SEGGER J-Link Software**](https://www.segger.com/downloads/jlink/#J-LinkSoftwareAndDocumentationPack)
 
-![](img/ble-primer/J-Link_Software_Download.png)
+![](/img/ble-primer/J-Link_Software_Download.png)
 <br/>
 
 This download (for macOS) is a .**pkg** installer file. Once you download it, simply double-click it and go through the installation process.
 
-![](img/ble-primer/J-Link_Installation.png)
+![](/img/ble-primer/J-Link_Installation.png)
 
 #### 4. GNU Arm Embedded Toolchain
 The next software package that we need to install is the GNU Arm Embedded Toolchain which includes the compiler (gcc) and debugger (gdb) for the Arm architecture (which the nRF52840 chipset is based on).
 
 **[Direct link to download the GNU Arm Embedded Toolchain (version 7-2017-q4-major)](https://developer.arm.com/-/media/Files/downloads/gnu-rm/7-2017q4/gcc-arm-none-eabi-7-2017-q4-major-mac.tar.bz2?revision=7f453378-b2c3-4c0d-8eab-e7d5db8ea32e?product=GNU%20Arm%20Embedded%20Toolchain,64-bit,,Mac%20OS%20X,7-2017-q4-major)**
 
-![](img/ble-primer/GNU_Arm_Embedded_Download.png)
+![](/img/ble-primer/GNU_Arm_Embedded_Download.png)
 <br/>
 
 After you download the package, simply extract it to your folder of choice.
 
-![](img/ble-primer/GNU_Arm_Download_Folder.png)
+![](/img/ble-primer/GNU_Arm_Download_Folder.png)
 
 
 #### 5. Serial Terminal Program
@@ -327,7 +327,7 @@ We will be using one of the BLE examples provided as part of the nRF5 SDK as a s
 
 The example is provided as a boilerplate template that you could use whenever you're developing an nRF52 BLE application from scratch. Here's a screenshot of the contents of this example's folder:
 
-![](img/ble-primer/ble_peripheral_folder.png)
+![](/img/ble-primer/ble_peripheral_folder.png)
 
 The example consists of a single source file named `main.c`, which we'll be modifying to do the following:
 
@@ -559,7 +559,7 @@ That's it for `main.c`! The source code for `main.c` is available on [GitHub](ht
 
 For implementation of our Simple Service we will create two source files: `simple_service.h` and `simple_service.c` and place them in the same folder as `main.c`.
 
-![](img/ble-primer/simple_service_files_folder.png)
+![](/img/ble-primer/simple_service_files_folder.png)
 
 ##### GATT Service and Characteristic UUIDs
 
@@ -584,7 +584,7 @@ The digits in **bold** represent the 16-bit value.
 
 We can simply generate one UUID for the Service and increment it for the Characteristic, and as long as it doesn't use the same "base" as the SIG Adopted UUIDs, we'll be good!
 
-![](img/ble-primer/online_guid_generator.png)
+![](/img/ble-primer/online_guid_generator.png)
 
 So, we'll use:
 
@@ -997,7 +997,7 @@ $ make
 
 Sometimes, it's a good idea to run `make clean` before running `make` just to make sure you are starting from a clean state. You should see an output similar to this when it finishes:
 
-![](img/ble-primer/make_output.png)
+![](/img/ble-primer/make_output.png)
 
 #### 2. Hardware Setup
 The second step is to get the hardware set up to run the example.
@@ -1011,7 +1011,7 @@ Here are the steps to accomplish this:
 	- **Power** set to "ON"
 	
 	<br/>
-	![](img/ble-primer/nRF52840_dev_kit.png)
+	![](/img/ble-primer/nRF52840_dev_kit.png)
 	
 - Erase the development kit by running the following command. This will erase the chipset on the board, just to make sure we are starting from a clean slate.
 
@@ -1047,13 +1047,13 @@ There are three parts to get this working:
 - Run the CoolTerm application
 - Make sure the serial port settings are correct (listed at [this link](https://infocenter.nordicsemi.com/topic/com.nordic.infocenter.sdk5.v15.3.0/uart_example.html)):
  
-	![](img/ble-primer/CoolTerm_Settings.png)
+	![](/img/ble-primer/CoolTerm_Settings.png)
 	
 	Now, hit **OK**. 
 
 - Finally, connect to the serial port by clicking the "Connect" button:
 	
-	![](img/ble-primer/CoolTerm_Connect.png)
+	![](/img/ble-primer/CoolTerm_Connect.png)
 	
 	You may not see any output since the program probably started before you connected. To reset the development board, we can simply run the following command from the Terminal:
 	
@@ -1063,7 +1063,7 @@ There are three parts to get this working:
 	
 The first time you run the application you'll most likely get an error that looks something like this:
 
-![](img/ble-primer/ram_offset_size_error.png)
+![](/img/ble-primer/ram_offset_size_error.png)
 
 This is due to the fact that we modified the value of the macro for the number of vendor-specific UUIDs in the SoftDevice. The good part is that the log output tells us exactly which values we need to use for RAM offset and RAM size to fix this problem.
 
@@ -1076,13 +1076,13 @@ and
 RAM (rwx) :  LENGTH
 ```
 
-![](img/ble-primer/linker_file.png)
+![](/img/ble-primer/linker_file.png)
 
 Now we just need to repeat the steps of cleaning, building, and flashing the SoftDevice, and application to the target.
 
 If all goes well, you should now see the following printed in the Terminal window:
 	
-![](img/ble-primer/CoolTerm_Output.png)
+![](/img/ble-primer/CoolTerm_Output.png)
 
 ### Testing the Application
 Even though we verified that our application is running correctly and no errors show up in the terminal window, we still need to verify its BLE functionality. The easiest way to do so is by running a BLE Central mobile app such as nRF Connect ([iOS](https://apps.apple.com/us/app/nrf-connect/id1054362403) or [Android](https://play.google.com/store/apps/details?id=no.nordicsemi.android.mcp&hl=en_US)) or LightBlue ([iOS](https://apps.apple.com/us/app/lightblue-explorer/id557428110) or [Android](https://play.google.com/store/apps/details?id=com.punchthrough.lightblueexplorer&hl=en_US)).
@@ -1100,28 +1100,28 @@ Let's go through each of these tests. We'll be using LightBlue for our tests her
 #### 1. Advertisements
 Once you launch LightBlue, you'll be presented with a screen showing all the BLE devices advertising in the vicinity. *Make sure you have Bluetooth enabled on your phone first*.
 
-![](img/ble-primer/lightblue_main_screen.png) 
+![](/img/ble-primer/lightblue_main_screen.png) 
 
 #### 2. Connection
 Now that we verified that we can discover our device ("Memfault_Example"), we can attempt to connect to it. Simply click on the device and it should initiate a connection. You should momentarily see a message similar to the following before it establishes the connection:
 
-![](img/ble-primer/lightblue_connecting.png)
+![](/img/ble-primer/lightblue_connecting.png)
 
 After the connection is established, you will be presented with a screen similar to this:
 
-![](img/ble-primer/device_connected.png)
+![](/img/ble-primer/device_connected.png)
 
 #### 3. GATT Service & Characteristic Discovery
 The previous screen also verifies that the Simple Service was discovered correctly and it contains our Button 1 Characteristic.
 
 If we click on the Simple Service, we should see the Button 1 Characteristic:
 
-![](img/ble-primer/simple_service.png)
+![](/img/ble-primer/simple_service.png)
 
 #### 4. Characteristic Value Read
 To verify that we can read the value of the Button 1 Characteristic, we can tap on "Read again". To verify further, we can hold down Button 1 on the development board and then click "Read again". This time it should display a value of 0x01.
 
-![](img/ble-primer/button_read.jpeg)
+![](/img/ble-primer/button_read.jpeg)
  
 #### 5. Notifications
 Finally, let's verify that we can get notified when the Button 1 state changes. We can do so by clicking on the "Listen for notifications" button.
@@ -1130,11 +1130,11 @@ Once you click on it, you can test it by pressing Button 1 and releasing it a fe
 
 Notifications disabled:
 
-![](img/ble-primer/notifications_disabled.png)
+![](/img/ble-primer/notifications_disabled.png)
 
 Notifications enabled:
 
-![](img/ble-primer/notifications_working.png)
+![](/img/ble-primer/notifications_working.png)
 
 ## Closing
 That's it for this post. We covered a whole lot here!

--- a/_posts/2019-08-06-a-deep-dive-into-arm-cortex-m-debug-interfaces.md
+++ b/_posts/2019-08-06-a-deep-dive-into-arm-cortex-m-debug-interfaces.md
@@ -40,7 +40,7 @@ The **Debug Port** can be used to configure transactions and read or write to on
 
 The most common type of Access Port is known as the `MEM-AP` which exposes an interface to different Memory buses available on a given ARM chip. On `ARM Cortex-M`, the `MEM-AP` which is typically accessed is known as the `AHB-AP`. The default APs that are selected can be found in the `APSEL` part of the **DP** `AP Select Register`[^1]:
 
-![](img/debuggers/apsel.png)
+![](/img/debuggers/apsel.png)
 
 #### AHB-AP
 
@@ -139,24 +139,24 @@ For this setup we will use:
 
 The end to end path of our debug setup looks like this:
 
-![](img/debuggers/debugger-nrf52840-dk.png)
+![](/img/debuggers/debugger-nrf52840-dk.png)
 
 The following image from the ARM Debug Interface Architecture manual[^2] captures what the path
 looks like inside the NRF52840. The "physical connection" in this case is the SWD path in the image above.
 
-![](img/debuggers/debugger-dp-ap.png)
+![](/img/debuggers/debugger-dp-ap.png)
 
 ## Prepping the board
 
 On the nRF52840-DK board I see `P18` is labeled as "Debug In". Looking at the schematics[^19], I can easily see the pinout:
 
-![](img/debuggers/p18-assignments.png)
+![](/img/debuggers/p18-assignments.png)
 
 I attached the Saleae ground to Pin 9, wire 0 to `SWDIO` at P18 Pin 2, and wire 1 to `SWDCLK` at P18 Pin 4.
 
 In the Saleae Logic App, I then enabled these 2 pins, and added the SWD analyzer:
 
-![](img/debuggers/saleae_setup.png)
+![](/img/debuggers/saleae_setup.png)
 
 ## Flashing the App
 
@@ -198,11 +198,11 @@ $4 = (int *) 0x20000108 <g_crash_config>
 
 The first transaction we see over the wire gets decoded by the Saleae as follows:
 
-![](img/debuggers/first_transaction.png)
+![](/img/debuggers/first_transaction.png)
 
 We see it's an `ABORT` Debug Port write. This is a good operation to run before issuing any transactions because it will reset the state of the current `AP` and put the debugger into a known state. If you wanted to decode the transaction without the Saleae analyzer, the ADIv5 reference manual[^2] provides the information needed. The structure for a write operation looks like this:
 
-![](img/debuggers/swd_write_op.png)
+![](/img/debuggers/swd_write_op.png)
 
 ### Saleae CSV Trace
 

--- a/_posts/2019-09-04-arm-cortex-m-exceptions-and-nvic.md
+++ b/_posts/2019-09-04-arm-cortex-m-exceptions-and-nvic.md
@@ -111,7 +111,7 @@ engines or General Purpose Input/Output Pins (**GPIO**s). All of these interrupt
 The **Exception Number** for external interrupts starts at **16**. The ARMv7-M reference manual has a good graphic which displays the Exception number mappings:
 
 {: #exception-number-diagram}
-![](img/armv-m-exceptions/exception-numbers.png)
+![](/img/armv-m-exceptions/exception-numbers.png)
 
 ## Registers used to configure Cortex-M Exceptions
 
@@ -132,7 +132,7 @@ sections below we will explore the highlights.
 ### Interrupt Control and State Register (ICSR) - 0xE000ED04
 
 `ICSR` bit assignments:
-![](img/armv-m-exceptions/icsr.png)
+![](/img/armv-m-exceptions/icsr.png)
 
 This register lets one control the NMI, PendSV, and SysTick exceptions and view a
 summary of the current interrupt state of the system.
@@ -149,7 +149,7 @@ The most useful status fields are:
 ### Application Interrupt and Reset Control Register (AIRCR) - 0xE000ED0C
 
 `AIRCR` bit assignments:
-![](img/armv-m-exceptions/aircr.png)
+![](/img/armv-m-exceptions/aircr.png)
 
 The highlights with respect to exceptions are:
 
@@ -178,7 +178,7 @@ all System Exceptions is 0, the highest configurable priority level. For most ap
 
 This register lets you view the status of or enable various built in exception handlers:
 
-![](img/armv-m-exceptions/shcsr.png)
+![](/img/armv-m-exceptions/shcsr.png)
 
 > NOTE: For ARMv6-M devices the only value which is implemented is `SVCALLPENDED`
 
@@ -188,7 +188,7 @@ This register lets you view the status of or enable various built in exception h
 
 This register allows you to determine the total number of external interrupt lines supported by an implementation. For ARMv6-M devices (Cortex-M0, Cortex-M0+), this register is not implemented because the number is always 32. For other Cortex-M MCUs, up to 496 lines may be supported! The layout of the register looks like this:
 
-![](img/armv-m-exceptions/ictr.png)
+![](/img/armv-m-exceptions/ictr.png)
 
 The exact number of interrupts supported is easily computed as `32 * (INTLINESNUM + 1)`
 

--- a/_posts/2019-09-17-continuous-integration-for-firmware.md
+++ b/_posts/2019-09-17-continuous-integration-for-firmware.md
@@ -170,13 +170,13 @@ You can find our fork at
 We’re now ready to set up CircleCI. Head to [https://circleci.com](https://circleci.com), create an account,
 select “Add Projects” in the sidebar, and search for your ChibiOS repository.
 
-![](img/circle-ci/search_chibios.png)
+![](/img/circle-ci/search_chibios.png)
 
 Click “Set Up Project” and follow the instructions. ChibiOS is a C project with
 robust tooling to build it on Linux, so we recommend you select “Linux” as the
 operating system, and “Other” as the language.
 
-![](img/circle-ci/setup_project.png)
+![](/img/circle-ci/setup_project.png)
 
 ### CircleCI Hello World
 
@@ -184,7 +184,7 @@ Now that we have a project set up, we need to tell our CI system how to build
 and test our firmware. In Circle CI this is done by defining a set of **Steps**,
 **Jobs**, and **Workflows**.
 
-![](img/circle-ci/Diagram-v3--Default.png)
+![](/img/circle-ci/Diagram-v3--Default.png)
 
 Simply stated, a **Step** is a single command to be run as part of your build
 and test process. It is the unit of work of our CI system. A **Job** is a
@@ -324,11 +324,11 @@ To github.com:memfault/ChibiOS.git
 
 Now head to [https://circleci.com](https://circleci.com) and observe that a new job has started:
 
-![](img/circle-ci/sample_build_started.png)
+![](/img/circle-ci/sample_build_started.png)
 
 Wait a bit, and you can look at the build result:
 
-![](img/circle-ci/sample_build_ended.png)
+![](/img/circle-ci/sample_build_ended.png)
 
 You should see the output of your two commands, and a successful result.
 
@@ -430,16 +430,16 @@ CircleCI will notice the pull request, pick up the new `config.yml` file and
 start running our build. If all goes well, we will see “All checks have passed”
 in Github:
 
-![](img/circle-ci/github_pull_request_success.png)
+![](/img/circle-ci/github_pull_request_success.png)
 
 Clicking through the check information in GitHub links us back to our CircleCI
 job page:
 
-![](img/circle-ci/real_build_ended.png)
+![](/img/circle-ci/real_build_ended.png)
 
 Where we can now find our artifacts! 
 
-![](img/circle-ci/chibios_artifact.png)
+![](/img/circle-ci/chibios_artifact.png)
 
 ### Automated Tests
 
@@ -546,7 +546,7 @@ workflows:
 Once again, we open a pull request with our changes, and watch CircleCI run our
 tests.
 
-![](img/circle-ci/github_build_and_test_pass.png)
+![](/img/circle-ci/github_build_and_test_pass.png)
 
 ## Final Thoughts
 

--- a/_posts/2019-09-24-ble-throughput-primer.md
+++ b/_posts/2019-09-24-ble-throughput-primer.md
@@ -64,7 +64,7 @@ For Bluetooth 4.0, the BLE Radio is capable of transmitting 1 symbol per microse
 
 All data during a BLE connection is sent via _Link Layer_ (**LL**) packets. All higher level messages are packed within _Data Payloads_ of _LL Packets_. Below is what a LL Packet sending data looks like (each tick mark represents 1 byte):
 
-![Data exchange](img/ble-throughput/ll_packet.png)
+![Data exchange](/img/ble-throughput/ll_packet.png)
 
 > NOTE: The astute reader may note that Data Payload can be up to 251 bytes. This however is an optional feature known as "LE Data Packet Length Extension" which we will explore in more detail [below](#ll-data-packet-length-extension)
 
@@ -80,7 +80,7 @@ With the three rules we mentioned about transmissions on the Bluetooth Radio in 
 - Side A waits `T_IFS` before sending any more data
 
 Here's an example exchange of two packets of data in one _Connection Event_:
-![Data exchange](img/ble-throughput/connection_event.png)
+![Data exchange](/img/ble-throughput/connection_event.png)
 
 The time it takes to transmit one packet can be computed as:
 
@@ -111,7 +111,7 @@ There are only a few different L2CAP channels used for Bluetooth Low Energy:
 
 Below is a diagram of the layout of an L2CAP packet. As you can see there are 4 bytes of overhead (Length + Channel ID) per packet sent.
 
-![Data exchange](img/ble-throughput/l2cap_packet.png)
+![Data exchange](/img/ble-throughput/l2cap_packet.png)
 
 ### Attribute Protocol (ATT) Packet
 
@@ -130,7 +130,7 @@ accomodate for the ATT protocol overhead), most bluetooth stacks support a maxim
 
 The packet looks like this:
 
-![Data exchange](img/ble-throughput/att_packet.png)
+![Data exchange](/img/ble-throughput/att_packet.png)
 
 {:.no_toc}
 
@@ -162,7 +162,7 @@ Over the years, the Bluetooth SIG has added a number of additions to the Low Ene
 
 As part of the 4.2 Bluetooth Core Specification revision, a new feature known as _LE Data Packet Length Extension_ was added [^1]. This _optional_ feature allows for a device to extend the length of the Data Payload in a [Link Layer packet](#ll-packet) from 27 up to 251 bytes! This means that instead of sending 27 bytes of data in a 41 byte payload, 251 bytes of data can now be sent in a 265 byte payload. Furthermore, we can send a lot more data with fewer `T_IFS` gaps. Let's take a look at what exchanging a maximally sized packet looks like:
 
-![](img/ble-throughput/ble-throughput-dple.png)
+![](/img/ble-throughput/ble-throughput-dple.png)
 
 We can calculate the raw data throughput and see that this modification yields greater than a _2x_ improvement on the maximum raw data throughput which can be achieved!
 
@@ -172,7 +172,7 @@ We can calculate the raw data throughput and see that this modification yields g
 
 As part of the 5.0 Bluetooth Core Specification revision, a new feature known as "LE 2M PHY"[^4] was added. As you may recall in the section [above](#ble-radio), we discussed how the BLE Radio is capable of transmitting 1 symbol per μs for a bitrate of 1Mbps. This revision to the Bluetooth Low Energy Physical Layer (PHY), allows for a symbol rate of 2Mbps. This means we can transmit each individual bit in half the time. However, the 150μs IFS is still needed between transmissions. Let's take a look on how this impacts the throughput when sending packets that are using the data packet length extension feature:
 
-![](img/ble-throughput/ble-throughput-dple-and-2m-phy.png)
+![](/img/ble-throughput/ble-throughput-dple-and-2m-phy.png)
 
 We can calculate this throughput and see the modification yields almost a _4x_ improvement over the original maximal raw data speed that could be achived with BLE 4.0
 
@@ -229,11 +229,11 @@ The number of packets which can be transmitted in one _connection event_ is limi
 
 The end of a connection event is controlled by the _More Data_ (_MD_) bit in the header of the link layer packet discussed [above](#ll-packet). The LL packet header looks like this:
 
-![](img/ble-throughput/ll-pdu-header.png)
+![](/img/ble-throughput/ll-pdu-header.png)
 
 A good description of how the MD bit works can be found in the Bluetooth Core Specification [^4]
 
-![](img/ble-throughput/ll-md-bit-desc.png)
+![](/img/ble-throughput/ll-md-bit-desc.png)
 
 If you have a protocol analyzer, you can analyze how the MD is being set to figure out what side of the connection is responsible for limiting the throughput.
 
@@ -243,7 +243,7 @@ If you have a protocol analyzer, you can analyze how the MD is being set to figu
 
 Many devices only support a subset of the valid connection parameter range (7.5ms - 4s). For example, Apple documents this information quite well in Section "25.6 Connection Parameters" of the "Accessory Design Guidelines For Apple Devices" [^7]:
 
-> ![](img/ble-throughput/apple-connection-parameters.png)
+> ![](/img/ble-throughput/apple-connection-parameters.png)
 
 A longer connection event in itself isn't necessarily a problem for throughput. Some devices will send and recieve data for an entire connection event so if you are streaming data continuously the same throughput can be realized even if you are using a 30ms interval instead of a 15ms interval.
 

--- a/_posts/2019-10-08-unit-testing-basics.md
+++ b/_posts/2019-10-08-unit-testing-basics.md
@@ -1143,7 +1143,7 @@ tests, so you can be sure that the piece of code was tested in some capacity.
 Note that code coverage doesn't measure the different behaviors a code path
 **could take**, but only that a particular code path **was taken**.
 
-![](img/unit-testing-basics/code_coverage.png)
+![](/img/unit-testing-basics/code_coverage.png)
 
 Above is a an example coverage report taken from the Memfault Public SDK[^5].
 

--- a/_posts/2019-10-22-best-and-worst-gcc-clang-compiler-flags.md
+++ b/_posts/2019-10-22-best-and-worst-gcc-clang-compiler-flags.md
@@ -489,7 +489,7 @@ occurs. The C standard defines this as[^17]:
 
 Then the following set of rules are applied to the promoted values:
 
-> ![](img/compiler-flags/arithmetic-conversions-int.png)
+> ![](/img/compiler-flags/arithmetic-conversions-int.png)
 
 It can be hard to keep track of the set of conversions taking place but fortunately the
 `-Wconversion` option can be used to generate warnings when **implicit** conversions that are

--- a/_posts/2019-10-30-cortex-m-rtos-context-switching.md
+++ b/_posts/2019-10-30-cortex-m-rtos-context-switching.md
@@ -137,7 +137,7 @@ at address `0xE000ED88` must take place.
 The layout can be found in the ARMv7 Reference Manual[^2]:
 
 {: #fpu-config-options}
-![](img/context-switching/cpacr-reg-layout.png)
+![](/img/context-switching/cpacr-reg-layout.png)
 
 where, `CP10` and `CP11` are used to control floating point availability. Both fields are 2 bits
 and must be identical to correctly configure the FPU.
@@ -157,7 +157,7 @@ Special Register_ (**MSR**) and _Move to Register from Special Register_ (**MRS*
 A full discussion of all the registers is outside the scope of this article but the ARM Reference
 Manual documentation about the instruction itself has a great overview [^2]:
 
-![](img/context-switching/mrs-msr-registers.png)
+![](/img/context-switching/mrs-msr-registers.png)
 
 There _are_ some special rules about the privilege level needed to read and write to the special
 registers worth remembering:
@@ -184,7 +184,7 @@ set one will see is:
 
 {: #control-register}
 
-![](img/context-switching/control-reg.png)
+![](/img/context-switching/control-reg.png)
 
 where
 
@@ -253,7 +253,7 @@ The reference manual has a great picture of what the stack looks like after this
 state saving takes place:
 
 {: #basic-context-state-frame}
-![](img/context-switching/context-state-stacking-basic.png)
+![](/img/context-switching/context-state-stacking-basic.png)
 
 {: #psr-alignment}
 
@@ -277,7 +277,7 @@ However, there's also some fine granularity controls about how the context is pr
 be configured via the _Floating Point Context Control Register_ (`FPCCR`) located at address
 `0xE000EF34`:
 
-![](img/context-switching/fpccr-reg.png)
+![](/img/context-switching/fpccr-reg.png)
 
 With respect to _Context State Stacking_, the values that are interesting are:
 
@@ -294,7 +294,7 @@ With respect to _Context State Stacking_, the values that are interesting are:
 When the FPU is "in use" (CONTROL.FPCA=1), an **extended frame** will be saved by the hardware:
 
 {: #extended-context-state-frame}
-![](img/context-switching/context-state-stacking-extended-frame.png)
+![](/img/context-switching/context-state-stacking-extended-frame.png)
 
 > NOTE: If the FPU is enabled but no floating point instructions are executed or ASPEN is disabled
 > (i.e CONTROL.FPCA=0), only the **basic frame** will be saved. The ARM **lazy context save** application
@@ -314,7 +314,7 @@ being used like we discussed [above](#stack-pointers-and-usage)).
 On exception entry, the ARM reference manual pseudocode for the value stored in `lr` gives the best description[^6]:
 
 {: #exception-entry-pseudocode}
-![](img/context-switching/lr-exc-return-exception-entry.png)
+![](/img/context-switching/lr-exc-return-exception-entry.png)
 
 It describes the current stack frame in use (**Extended** vs **Basic**) as well as what the active
 stack pointer was prior to the exception taking place.

--- a/_posts/2019-11-20-cortex-m-fault-debug.md
+++ b/_posts/2019-11-20-cortex-m-fault-debug.md
@@ -49,7 +49,7 @@ If you are trying to debug a Cortex-M0, you can skip ahead to the [next section]
 
 This 32 bit register contains a summary of the fault(s) which took place and resulted in the exception. The register is comprised of three different status registers -- UsageFault, BusFault & MemManage Fault Status Registers:
 
-![](img/cortex-m-fault/cfsr.png)
+![](/img/cortex-m-fault/cfsr.png)
 
 The register can be accessed via a 32 bit read at `0xE000ED28` or each register can be read individually. For example, in GDB it would look something like this:
 
@@ -66,7 +66,7 @@ The register can be accessed via a 32 bit read at `0xE000ED28` or each register 
 
 This register is a 2 byte register which summarizes any faults that are not related to memory access failures, such as executing invalid instructions or trying to enter invalid states.
 
-![](img/cortex-m-fault/ufsr.png)
+![](/img/cortex-m-fault/ufsr.png)
 
 where,
 
@@ -96,7 +96,7 @@ It is worth noting that some classes of UsageFaults are configurable via the _Co
 
 This register is a 1 byte register which summarizes faults related to instruction prefetch or memory access failures.
 
-![](img/cortex-m-fault/bfsr.png)
+![](/img/cortex-m-fault/bfsr.png)
 
 - `BFARVALID` - Indicates that the _Bus Fault Address Register_ (**BFAR**), a 32 bit register located at `0xE000ED38`, holds the address which triggered the fault. We'll walk through an example using this info [below](#bad-address-read-example).
 - `LSPERR` & `STKERR` - Indicates that a fault occurred during lazy state preservation or during exception entry, respectively. Both are situations where the hardware is [automatically saving state on the stack](https://interrupt.memfault.com/blog/cortex-m-rtos-context-switching#context-state-stacking). One way this error may occur is if the stack in use overflows off the valid RAM address range while trying to service an exception. We'll go over an example [below](#stkerr-example).
@@ -127,7 +127,7 @@ For the Cortex M7, there is **no** way to force all stores to be synchronous / p
 
 This register **only** exists for Cortex-M7 devices. When an `IMPRECISE` error occurs it will at least give us an indication of what memory bus the fault occurred on[^7]:
 
-![](img/cortex-m-fault/abfsr.png)
+![](/img/cortex-m-fault/abfsr.png)
 
 A full discussion of memory interfaces is outside the scope of this article but more details can be found in the reference manual [^7].
 
@@ -141,7 +141,7 @@ Typically MPU faults will only trigger if the MPU has been [configured and enabl
 
 The layout of the register looks like this:
 
-![](img/cortex-m-fault/mmfsr.png)
+![](/img/cortex-m-fault/mmfsr.png)
 
 where,
 
@@ -155,7 +155,7 @@ where,
 
 This registers explains the reason a HardFault exception was triggered.
 
-![](img/cortex-m-fault/hfsr.png)
+![](/img/cortex-m-fault/hfsr.png)
 
 There's not too much information in this register but we will go over the fields real quickly
 
@@ -419,7 +419,7 @@ Alternatively, an end-to-end firmware error analysis system, such as
 [Memfault](https://memfault.com/features/error-analysis.html?utm_source=interrupt&utm_medium=link&utm_campaign=cortex-m-faults),
 can be used to automatically collect, transport, deduplicate and surface the faults and crashes happening in the field. Here is some example output from Memfault for the bad memory read example we will walk through [below](#bad-address-read-example):
 
-![](img/cortex-m-fault/memfault-fault-analyzer.png)
+![](/img/cortex-m-fault/memfault-fault-analyzer.png)
 
 {: #recovering-from-a-fault}
 


### PR DESCRIPTION
In our image links we were not prefixing with a `/`. This meant if
someone navigated to a blog post and had a `/` at the end of the url,
the image would be searched for the wrong location

i.e

https://interrupt.memfault.com/blog/cortex-m-fault-debug/

would result in a lookup of `img/cortex-m-fault/cfsr.png` resolving to:

https://interrupt.memfault.com/blog/cortex-m-fault-debug/img/cortex-m-fault/cfsr.png

We need to prefix all of our image urls with a '/' so the search for
the image is always relative to the [root of the
website](https://www.w3schools.com/html/html_filepaths.asp)

This change updates all the urls ...
`rg "\[.*\]\(img" -l | xargs -I {} gsed -i "s|](img/|](/img/|g" {}`