### PR TITLE
Expose a tag page for easier discovery of articles about particular topics

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -40,6 +40,9 @@ plugins:
   - jekyll-paginate
   - jekyll-seo-tag
 
+tag_page: '/tags/'
+category_page: '/categories/'
+
 # Custom variables
 version: "1.1.0"
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -21,7 +21,7 @@
   <!-- CSS & fonts -->
   <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl | replace: '//', '/' }}">
   <link href='https://fonts.googleapis.com/css?family=Source+Code+Pro:400%7CSource+Sans+Pro:300,400,700,900,400italic%7CSignika:700,300,400,600' rel='stylesheet' type='text/css'>
-
+  <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.3/css/font-awesome.min.css" rel="stylesheet">
   <!-- RSS -->
   <link href="/feed.xml" type="application/rss+xml" rel="alternate" title="RSS 2.0 Feed" />
 

--- a/_includes/header-custom.html
+++ b/_includes/header-custom.html
@@ -9,5 +9,6 @@
   </a>&nbsp;&nbsp;&nbsp;&nbsp;
   <a href="http://eepurl.com/gpRedv">Subscribe</a>&nbsp;&nbsp;&nbsp;&nbsp;
   <a href="/contributing">Contribute</a>&nbsp;&nbsp;&nbsp;&nbsp;
+  <a href="/tags">Tags</a>&nbsp;&nbsp;&nbsp;&nbsp;
   <a href="https://community.memfault.com">Community</a>&nbsp;&nbsp;&nbsp;&nbsp;
 </header>

--- a/_layouts/tag.html
+++ b/_layouts/tag.html
@@ -10,7 +10,7 @@ layout: default
     {% if post.tags contains page.tag %}
 
     <li class="post">
-        <h2><a href="{% if site.baseurl == "/" %}{{ post.url }}{% else %}{{ post.url | prepend: site.baseurl }}{% endif %}">{{ post.title }}</a></h2> 
+        <h2><a href="{% if site.baseurl == "/" %}{{ post.url }}{% else %}{{ post.url | prepend: site.baseurl }}{% endif %}">{{ post.title }}</a></h2>
         <div class="by-line">
             <time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date_to_string }}</time>
             {% assign author = site.data.authors[post.author] %}

--- a/_sass/base.scss
+++ b/_sass/base.scss
@@ -25,6 +25,8 @@ $background-color: #FDFDFD;
 $text-color: #222222;
 $link-color: $main-color;
 
+$theme-color: $main-color;
+
 // Dark theme (not used)
 $main-color-dark: #FDFDFD;
 $background-color-dark: #141845;

--- a/_sass/tag.scss
+++ b/_sass/tag.scss
@@ -1,0 +1,66 @@
+.post-tag {
+  display: inline-block;
+  background: rgba($theme-color, 0.15);
+  padding: 0 .5rem;
+  margin-right: .5rem;
+  border-radius: 4px;
+  color: $theme-color;
+/*  font-family: $font-sans; */
+  font-size: 90%;
+  &:before {
+    content: "\f02b";
+    /*    font-family: $font-font-awesome; */
+    font-family: FontAwesome;
+    padding-right: .5em;
+  }
+  &:hover {
+    text-decoration: none;
+    background: $theme-color;
+    color: #fff;
+  }
+/*  @include transition(all .1s ease-in-out); */
+}
+
+.tags-expo {
+  :target:before {
+    content:"";
+    display:block;
+    height:72px; /* fixed header height*/
+    margin:-72px 0 0; /* negative fixed header height */
+  }
+  .tags-expo-list {
+    @media (min-width: 38em) {
+      font-size: 0.9rem;
+      .post-tag {
+        margin: .2em .3em;
+      }
+    }
+  }
+  .tags-expo-section {
+    ul {
+      list-style-type: circle;
+      list-style-position: inside;
+      padding: 0;
+      li {
+/*        @include transition(all .1s ease-in-out); */
+        padding: 0 1rem;
+        &:hover {
+          list-style-type: disc;
+          padding: 0 .5rem;
+        }
+      }
+    }
+    a {
+      text-decoration: none;
+    }
+    .post-date {
+      display: inline-block;
+      font-size: 80%;
+      /*      color: $post-date-color; */
+      color: #9a9a9a;
+      margin: 0;
+      padding: 0;
+    }
+/*    font-family: $font-sans; */
+  }
+}

--- a/css/main.scss
+++ b/css/main.scss
@@ -3,4 +3,4 @@
 ---
 
 //Import
-@import "base", "mixin", "typography", "layout", "syntax.scss", "custom.scss";
+@import "base", "mixin", "typography", "tag", "layout", "syntax.scss", "custom.scss";

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@ layout: default
     {% for post in paginator.posts %}
 
     <li class="post">
-        <h2><a href="{% if site.baseurl == "/" %}{{ post.url }}{% else %}{{ post.url | prepend: site.baseurl }}{% endif %}">{{ post.title }}</a></h2> 
+        <h2><a href="{% if site.baseurl == "/" %}{{ post.url }}{% else %}{{ post.url | prepend: site.baseurl }}{% endif %}">{{ post.title }}</a></h2>
         <div class="by-line">
             <time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date_to_string }}</time>
             {% assign author = site.data.authors[post.author] %}

--- a/tags.html
+++ b/tags.html
@@ -1,0 +1,29 @@
+---
+layout: page
+title: Tags
+---
+
+<div class="tags-expo">
+    <div class="tags-expo-list">
+    {% assign sorted_tags = site.tags | sort %}
+    {% for tag in sorted_tags %}
+    <a href="#{{ tag[0] | slugify }}" class="post-tag">{{ tag[0] }}</a>
+    {% endfor %}
+  </div>
+  <hr/>
+  <div class="tags-expo-section">
+    {% for tag in sorted_tags %}
+    <h2 id="{{ tag[0] | slugify }}">{{ tag[0] }}</h2>
+    <ul class="tags-expo-posts">
+      {% for post in tag[1] %}
+        <a class="post-title" href="{{ site.baseurl }}{{ post.url }}">
+      <li>
+        {{ post.title }}
+      <small class="post-date">{{ post.date | date_to_string }}</small>
+      </li>
+      </a>
+      {% endfor %}
+    </ul>
+    {% endfor %}
+  </div>
+</div>


### PR DESCRIPTION
Inspired from [here](https://codinfox.github.io/dev/2015/03/06/use-tags-and-categories-in-your-jekyll-based-github-pages/)