### PR TITLE
Improve Jekyll build time

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -50,3 +50,18 @@ version: "1.1.0"
 custom_header: true
 custom_nav_footer: true
 reverse: false
+
+# Exclude these files from the build
+exclude:
+  - .sass-cache/
+  - .jekyll-cache/
+  - gemfiles/
+  - Gemfile
+  - Gemfile.lock
+  - node_modules/
+  - vendor/
+  - vendor/bundle/
+  - vendor/cache/
+  - vendor/gems/
+  - vendor/ruby/
+  - example


### PR DESCRIPTION
I noticed after I added a bunch of source files to the example folder that
Jekyll was trying to *build* these files, and running a `make` in the
example directory was causing a very long rebuild.

After some exploration, it appears there's an `exclude` option we should be
using to exclude some of the folders.

https://github.com/jekyll/jekyll/blob/master/lib/site_template/_config.yml

I used to see build times times from around 20-30s, now I see 2-6 seconds.
Woo!