### PR TITLE
Add internal linking for older posts

### DIFF
--- a/_posts/2019-04-25-getting-started-with-ibdap-and-atsamd21g18.md
+++ b/_posts/2019-04-25-getting-started-with-ibdap-and-atsamd21g18.md
@@ -15,7 +15,7 @@ the next poor soul wrestling with these systems.
 Note: I'm a MacOS user, but the procedure below will work fine on Linux /
 Windows with some adjustments.
 
-### Setting up the IBDAP programmer
+## Setting up the IBDAP programmer
 
 I had recently picked up an [IBDAP](https://www.adafruit.com/product/2764)
 programmer from Adafruit. This is a simple CMSIS-DAP device based on the
@@ -51,7 +51,7 @@ within the flash and OSX wants some overhead, erroring out with "not enough spac
 
 You are now the proud owner of a functional IBDAP programmer!
 
-### Installing OpenOCD
+## Installing OpenOCD
 
 Installing OpenOCD with all the right dependencies to do CMSIS-DAP was once
 trickier than it ought to be. Today, the Homebrew formula takes care of it all
@@ -68,7 +68,7 @@ For bug reports, read
 ```
 Huzzah!
 
-### Flashing the atsamd21g18
+## Flashing the atsamd21g18
 
 Both the Arduino M0 pro and the Metro M0 Express boards come with fancy
 bootloaders that let you [update your firmware over

--- a/_posts/2019-05-14-zero-to-main-1.md
+++ b/_posts/2019-05-14-zero-to-main-1.md
@@ -22,7 +22,7 @@ and your main function is called. In the process, we'll learn how to bootstrap a
 C environment, implement a bootloader, relocate code, and more!
 <!-- excerpt end -->
 
-### Setting the stage
+## Setting the stage
 
 While most of the concepts and code presented in this series should work for all
 Cortex-M series MCUs, our examples target the SAMD21G18 processor by Atmel. This
@@ -66,7 +66,7 @@ int main() {
 ```
 
 
-### Power on!
+## Power on!
 
 So how did we get to main? All we can tell from observation is that we applied
 power to the board and our code started executing. There must be behavior
@@ -159,7 +159,7 @@ instructions, which is one of the two instruction sets supported by ARM
 processors, so `Reset_Handler` is what we're looking for (for more details check
 out section A4.1.1 in the ARMv6-M manual).
 
-### Writing a Reset_Handler
+## Writing a Reset_Handler
 
 Unfortunately, the Reset_Handler is often an inscrutable mess of Assembly code.
 See the [nRF52 SDK
@@ -312,14 +312,17 @@ You will note that we added two things:
    `Reset_Handler` before `main`. This is the approach [taken by
 Nordic](https://github.com/NordicSemiconductor/nrfx/blob/6f54f689e9555ea18f9aca87caf44a3419e5dd7a/mdk/system_nrf52811.c#L60).
 
+## Closing
+
 All the code used in this blog post is available on 
 [Github](https://github.com/memfault/zero-to-main/tree/master/minimal). See
 anything you'd like to change? Submit a pull request!
 
 More complex programs often require a more complicated `Reset_Handler`. For
 example:
-1. If our program relies on libc, we must initialize it
-2. Relocatable code must be copied over
+1. Relocatable code must be copied over  
+2. If our program relies on libc, we must initialize it  
+  _EDIT: Post written!_ - [From Zero to main(): Bootstrapping libc with Newlib]({% post_url 2019-11-12-boostrapping-libc-with-newlib %})
 3. More complex memory layouts can add a few copy / zero loops
 
 We'll cover all of them in future posts. But before that, 
@@ -327,3 +330,4 @@ we'll talk about how the magical memory region variables come about,
 how our `Reset_Handler`'s address ends up at `0x00000004`, and how to write a
 linker script in our next post!
 
+_EDIT: Post written!_ - [From Zero to main(): Demystifying Firmware Linker Scripts]({% post_url 2019-06-25-how-to-write-linker-scripts-for-firmware %})

--- a/_posts/2019-05-21-gdb-for-firmware-1.md
+++ b/_posts/2019-05-21-gdb-for-firmware-1.md
@@ -1,6 +1,8 @@
 ---
 title: "Debugging Firmware with GDB"
+description: "How to set up, flash, and debug firmware on a Nordic nRF52 using GDB, a Segger J-Link, and the GNU ARM Embedded Toolchain."
 author: mafaneh
+tags: [gdb]
 ---
 
 <!-- excerpt start -->
@@ -77,7 +79,7 @@ In order to use GDB with any embedded system, we need to set up:
 Let's go through the different steps for downloading the necessary software packages.
 
 For each of these downloads, you can place them anywhere on your machine. I recommend having them all in a single folder, to make it easier to locate later on.
-#### 1. nRF5 SDK
+### 1. nRF5 SDK
 Installation of the nRF5 SDK is straightforward. All you need to do is download the SDK tarball from Nordic's website and then extract it.
 
 **[Link to download nRF5 SDK](https://www.nordicsemi.com/Software-and-Tools/Software/nRF5-SDK/Download#infotabs)**
@@ -88,7 +90,7 @@ Once you extract it, you should see the following directory structure:
 ![](/img/gdb-tips-and-tricks/nRF5_SDK_folder.png)
 
 
-#### 2. nRF5 Command Line Tools
+### 2. nRF5 Command Line Tools
 Next, we need to install the nRF5 Command Line Tools. These include **nrfjprog**, which is a tool for programming your nRF52 development kit via the Segger J-Link debugger and needed in our case for working from the command line.
 
 **[Link to download the nRF5 Command Line Tools](https://www.nordicsemi.com/Software-and-Tools/Development-Tools/nRF5-Command-Line-Tools/Download#infotabs)**
@@ -105,7 +107,7 @@ This is what the contents of the folder should look like:
 
 ![](/img/gdb-tips-and-tricks/nRF5_Command_Line_Tools_Folder.png)
 
-#### 3. SEGGER J-Link
+### 3. SEGGER J-Link
 The SEGGER J-Link software is needed for the GDB Server interface to the nRF52 chipset on the development kit.
 
 So let's go ahead and download the software.
@@ -122,7 +124,7 @@ This download (for macOS) is a .**pkg** installer file. Once you download it, si
 ![](/img/gdb-tips-and-tricks/J-Link_Installation.png)
 
 
-#### 4. GNU Arm Embedded Toolchain
+### 4. GNU Arm Embedded Toolchain
 The next software package that we need to install is the GNU Arm Embedded Toolchain which includes the compiler (gcc) and debugger (gdb) for the Arm architecture (which the nRF52840 chipset is based on).
 
 **[Direct link to download the GNU Arm Embedded Toolchain (version 7-2017-q4-major)](https://developer.arm.com/-/media/Files/downloads/gnu-rm/7-2017q4/gcc-arm-none-eabi-7-2017-q4-major-mac.tar.bz2?revision=7f453378-b2c3-4c0d-8eab-e7d5db8ea32e?product=GNU%20Arm%20Embedded%20Toolchain,64-bit,,Mac%20OS%20X,7-2017-q4-major)**
@@ -137,14 +139,14 @@ After you download the package, simply extract it to your folder of choice.
 ![](/img/gdb-tips-and-tricks/GNU_Arm_Download_Folder.png)
 
 
-#### 5. Serial Terminal Program
+### 5. Serial Terminal Program
 My choice for a terminal program that I use across projects is a program called **CoolTerm**. What I like about this program is its simplicity and that it supports all the major platforms (Windows, macOS, and Linux).
 
 **[Link to download CoolTerm](https://freeware.the-meiers.org/CoolTermMac.zip)**
 
 For now, all you need to do is download it, open the package and copy the application file to your Mac **Applications** folder so you could launch it in the later steps.
 
-#### 6. Adding Necessary Folders to $PATH
+### 6. Adding Necessary Folders to $PATH
 In order to access the necessary commands that we'll be calling from anywhere in your system, you need to add their paths to the system **$PATH** environment variable.
 
 To do that, open up a Terminal session and type the following:
@@ -499,7 +501,8 @@ We hope this post served as a good starting point for using GDB, or a refresher 
 
 Some ideas for future GDB-related posts include:
 
-- GDB scripting and automation
+- GDB scripting and automation  
+  _EDIT: Post written!_ - [Automate Debugging with GDB Python API]({% post_url 2019-07-02-automate-debugging-with-gdb-python-api %})
 - Debugging nRF5x SoftDevice-based applications
 
 What other GDB tips and tricks do you know? Are you facing any problems or struggles with using GDB?

--- a/_posts/2019-06-06-best-firmware-size-tools.md
+++ b/_posts/2019-06-06-best-firmware-size-tools.md
@@ -1,5 +1,5 @@
 ---
-title: "Code Size Optimization: Measure Twice, Cut Once"
+title: "Tools for Firmware Code Size Optimization"
 description: "Overview of useful tools such as GNU size, nm, and puncover to help reduce code size usage of an ARM firmware binary"
 author: francois
 tags: [fw-code-size]
@@ -13,7 +13,8 @@ Whether they are trying to cram in another feature, or to make enough space for
 updates](https://sbabic.github.io/swupdate/overview.html#double-copy-with-fall-back)
 more code space is always better.
 
-In this series of posts, we'll explore ways to save code space and ways not to
+In this [series of posts]({{ '/tag/fw-code-size' | relative_url }}) 
+series of posts, we'll explore ways to save code space and ways not to
 do it. We will cover compiler options, coding style, logging, as well as
 desperate hacks when all you need is another 24 bytes.
 
@@ -21,7 +22,7 @@ But first, let's talk about measuring code size.
 
 <!-- excerpt end -->
 
-### Why measure?
+## Why measure?
 
 Optimization is often counter intuitive. Don't take my word for it: this is one
 of the topics [Microsoft's Raymond
@@ -32,7 +33,7 @@ agree on!
 So before you do anything, measure where your code size is going. You may be
 surprised!
 
-### Measuring overall code size
+## Measuring overall code size
 
 The simplest way to measure code size is to inspect the different sections of
 your elf file. The ARM GCC toolchain comes with a handy utility to do just that:
@@ -157,7 +158,7 @@ This falls into the same pitfall as `size` in that it does not count `data`
 against ROM, and gives us less info since it does not break RAM out into `data`
 and `bss`.
 
-### Digging into functions
+## Digging into functions
 
 The above tells us *how much* code space we are using, but not *why*. To answer
 the latter, we need to go deeper.
@@ -211,7 +212,7 @@ Note: you can also add `-l` to get filename & line # for each symbol.
 Here we see that our largest symbol is `_usart_set_config` which uses 692
 bytes of flash.
 
-### Puncover
+## Puncover
 
 Although you can get quite far with the ARM GNU tools, my favorite tool for code
 size analysis by far is [Puncover](https://github.com/memfault/puncover).
@@ -233,7 +234,7 @@ Truly, it is a firmware analysis swiss army knife!
 Using puncover is relatively straightforward. You'll need to lightly prepare
 your codebase, setup the tool itself, and run it.
 
-### Preparing our codebase
+## Preparing our codebase
 
 In order to for puncover to work, our elf file needs to contain the requisite
 information. As such, you'll need to make sure you've got the following CFLAGS
@@ -248,7 +249,7 @@ Even better would be to use your repository's root (usually found by running
 I typically add those two to my CFLAGS for every project directly in my
 Makefile.
 
-### Setting up puncover
+## Setting up puncover
 
 Puncover is relatively straightforward to setup: you simply need to clone it,
 setup a virtualenv, and install the dependencies.
@@ -282,7 +283,7 @@ mock-1.3.0 nose-1.3.7 nose-cov-1.6 pbr-5.2.0 requests-2.21.0 six-1.12.0
 urllib3-1.24.3
 ```
 
-### Running puncover
+## Running puncover
 
 While you can install puncover as an executable, I typically just run the
 `runner.py` script directly. All it requires is the path to your GNU ARM
@@ -323,7 +324,7 @@ symbols do not come with file information as newlib is not compiled with `-g` in
 most distributions. If you built your own newlib from source, you could fix
 that!
 
-### Epilogue
+## Epilogue
 
 Upon reviewing this blog post, a friend suggested I look at Bloaty by Google.
 You can check it out on [Github](https://github.com/google/bloaty) or just

--- a/_posts/2019-06-25-how-to-write-linker-scripts-for-firmware.md
+++ b/_posts/2019-06-25-how-to-write-linker-scripts-for-firmware.md
@@ -10,7 +10,7 @@ This is the second post in our [Zero to main() series]({{ '/tag/zero-to-main' |
 relative_url  }}).
 
 <!-- excerpt start -->
-[Last time](https://interrupt.memfault.com/blog/zero-to-main-1), we talked about
+[Last time]({% post_url 2019-05-14-zero-to-main-1 %}), we talked about
 bootstrapping a C environment on an MCU before invoking our `main` function. One
 thing we took for granted was the fact that functions and data end up in the
 right place in our binary. Today, we're going to dig into how that happens by
@@ -38,7 +38,7 @@ Github](https://github.com/memfault/zero-to-main/blob/master/minimal).
 *Like Interrupt? [Subscribe](http://eepurl.com/gpRedv) to get our latest
 posts straight to your mailbox*
 
-### A brief primer on linking
+## Brief Primer on Linking
 
 Linking is the last stage in compiling a program. It takes a number of compiled
 object files and merges them into a single program, filling in addresses so
@@ -96,7 +96,7 @@ this conversation, we will not cover these topics.
 For more information on the linker, there's a great thread on [Stack
 Overflow](https://stackoverflow.com/questions/3322911/what-do-linkers-do).
 
-### Anatomy of a linker script
+## Anatomy of a Linker Script
 
 A linker script contains four things:
 * Memory layout: what memory is available where
@@ -104,7 +104,7 @@ A linker script contains four things:
 * Options: commands to specify architecture, entry point, ...etc. if needed
 * Symbols: variables to inject into the program at link time
 
-### Memory Layout
+## Memory Layout
 
 In order to allocate program space, the linker needs to know how much memory is
 available, and at what addresses that memory exists. This is what the `MEMORY`
@@ -167,7 +167,7 @@ MEMORY
 }
 ```
 
-### Section Definitions
+## Section Definitions
 
 Code and data are bucketed into sections, which are contiguous areas of memory.
 There are no hard rules about how many sections you should have, or what they
@@ -227,7 +227,7 @@ No symbols! While the linker is able to make asumptions that will allow it to
 link in symbols with little information, but it at least needs to know either
 what the entry point should be, or what symbols to put in the text section.
 
-#### .text
+### `.text` Section
 
 Let's start by adding our `.text` section. We want that section in ROM. The
 syntax is simple:
@@ -336,7 +336,7 @@ SYMBOL TABLE:
 ...
 ```
 
-#### .bss
+### `.bss` Section
 
 Now, let's take care of our `.bss`. Remember, this is the section we put
 uninitialized static memory in. `.bss` must be reserved in the memory map, but there
@@ -363,7 +363,7 @@ have the same name.
 We indicate that this section is not loaded with the `NOLOAD` property. This is
 the only section property used in modern linker scripts.
 
-#### .stack
+### `.stack` Section
 
 We do the same thing for our `.stack` memory, since it is in RAM and not loaded.
 As the stack contains no symbols, we must explicitly reserve space for it by
@@ -398,7 +398,7 @@ SECTION {
 
 Only one more section to go!
 
-#### .data
+### `.data` Section
 
 The `.data` section contains static variables which have an
 initial value at boot. You will remember from our previous article that since RAM
@@ -443,7 +443,7 @@ can enter an address in hex as well.
 
 And we're done! Here's our complete linker script with every section:
 
-#### Complete Linker Script
+### Complete Linker Script
 
 ```
 MEMORY
@@ -492,7 +492,7 @@ You can find the full details on linker script sections syntax in the
 [ld
 manual](https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/4/html/Using_ld_the_GNU_Linker/sections.html#OUTPUT-SECTION-DESCRIPTION).
 
-### Variables
+## Variables
 
 In the first post, our `ResetHandler` relied on seemingly magic variables to know
 the address of each of our sections of memory. It turns out, those variable came
@@ -552,3 +552,22 @@ uint8_t *data_byte = &_sdata;
 
 You can read more details about this in the [binutils
 docs](https://sourceware.org/binutils/docs/ld/Source-Code-Reference.html).
+
+
+## Closing
+
+I hope this post gave you confidence in writing your own linker scripts. 
+
+In my next post, we'll talk about writing a bootloader to assist with loading
+and starting your application.
+
+_EDIT: Post written!_ - [Writing a Bootloader from Scratch]({% post_url 2019-08-13-how-to-write-a-bootloader-from-scratch %})
+
+As with previous posts, code examples are available on Github in the [zero to main
+repository](https://github.com/memfault/zero-to-main)
+
+See anything you'd like to change? Submit a pull request or open an issue at
+[Github](https://github.com/memfault/interrupt)
+
+_Like Interrupt? [Subscribe](http://eepurl.com/gpRedv) to get our latest posts
+straight to your mailbox_

--- a/_posts/2019-07-02-automate-debugging-with-gdb-python-api.md
+++ b/_posts/2019-07-02-automate-debugging-with-gdb-python-api.md
@@ -7,7 +7,7 @@ tags: [python, gdb]
 
 <!-- excerpt start -->
 
-[Previously](https://interrupt.memfault.com/blog/gdb-for-firmware-1#debugging-firmware-with-gdb) we discussed how a significant portion of developer time is spent _debugging_ firmware and how GDB can be a powerful utility for this. In this article we will discuss how to become more efficient at debugging by leveraging GDB's [Python API](https://sourceware.org/gdb/onlinedocs/gdb/Python.html#Python).
+[Previously]({% post_url 2019-05-21-gdb-for-firmware-1 %}) we discussed how a significant portion of developer time is spent _debugging_ firmware and how GDB can be a powerful utility for this. In this article we will discuss how to become more efficient at debugging by leveraging GDB's [Python API](https://sourceware.org/gdb/onlinedocs/gdb/Python.html#Python).
 
 <!-- excerpt end -->
 
@@ -384,8 +384,12 @@ Alternatively, you could also get this to run automatically when gdb is started 
 
 ## Closing
 
-We hope this post gave you a useful overview of how to add custom GDB commands and pretty printers using the Python API. Sometimes adding GDB commands like these can even be used to reduce [code size](https://interrupt.memfault.com/blog/best-firmware-size-tools) by replacing a on-device CLI command that would display the same information!
+We hope this post gave you a useful overview of how to add custom GDB commands and pretty printers using the Python API. Sometimes adding GDB commands like these can even be used to reduce [code size]({% post_url 2019-06-06-best-firmware-size-tools %}) by replacing a on-device CLI command that would display the same information!
 
 Do you already have some ideas about how the Python API could be applied to automate parts of your debugging flow ... perhaps a command to walk custom heaps or display the contents in a memory-mapped filesystem? Or maybe you are already have some great examples of how you have used GDB Python? Either way, let us know in the discussion area below!
+
+Next time, we'll talk about how to use third-party Python packages within GDB using virtual environments. 
+
+_EDIT: Post written!_ - [Using Python PyPi Packages with GDB]({% post_url 2019-07-23-using-pypi-packages-with-GDB %}) 
 
 _All the code used in this blog post is available on [Github](https://github.com/memfault/interrupt/tree/master/example/gdb-python-post/). See anything you'd like to change? Submit a pull request!_

--- a/_posts/2019-07-09-get-the-most-out-of-the-linker-map-file.md
+++ b/_posts/2019-07-09-get-the-most-out-of-the-linker-map-file.md
@@ -223,7 +223,7 @@ Following the memory configuration is the **Linker script and memory map**. That
 
 Those lines give us the address of each function and its size. Above, you can read the address of `bsp_board_led_invert`, coming from `boards.c.o` (compilation unit of `board.c` as you guessed) which has a size of 0x34 bytes in the `text` area. That way, we are able to locate each function used in the program.
 
-My constant string `_delay_ms_str` is obviously included in the program as it is initialized. Read-only data are saved as `rodata` and kept in the `FLASH` region as specified in the [linker script](https://interrupt.memfault.com/blog/how-to-write-linker-scripts-for-firmware) (stored in Flash and not copied in RAM as it is constant). I can find it under that line:
+My constant string `_delay_ms_str` is obviously included in the program as it is initialized. Read-only data are saved as `rodata` and kept in the `FLASH` region as specified in the [linker script]({% post_url 2019-06-25-how-to-write-linker-scripts-for-firmware %}) (stored in Flash and not copied in RAM as it is constant). I can find it under that line:
 
 ```
     .rodata.main.str1.4
@@ -336,7 +336,7 @@ Now if you want to make your program safer and prevent accessibility of some glo
 
 ---
 
-Several usages of the map file are possible. Most of the time, you will have an address and you will want to resolve the function behind. It can be the Program Counter in the Hard Fault handler for example. Some other times you will be debugging some undefined behavior to finally find out that your program is accidentally writing into an out-of-bounds array. Whenever you have the ELF file, `arm-none-eabi-nm` is pretty useful for those things too, and it comes with options to sort symbols by size, [check out this article from François](https://interrupt.memfault.com/blog/best-firmware-size-tools).
+Several usages of the map file are possible. Most of the time, you will have an address and you will want to resolve the function behind. It can be the Program Counter in the Hard Fault handler for example. Some other times you will be debugging some undefined behavior to finally find out that your program is accidentally writing into an out-of-bounds array. Whenever you have the ELF file, `arm-none-eabi-nm` is pretty useful for those things too, and it comes with options to sort symbols by size, [check out this article from François]({% post_url 2019-06-06-best-firmware-size-tools %}).
 
 But some other times, it will be useful even before you have an executable ready...
 

--- a/_posts/2019-07-16-fix-bugs-and-secure-firmware-with-the-mpu.md
+++ b/_posts/2019-07-16-fix-bugs-and-secure-firmware-with-the-mpu.md
@@ -43,7 +43,7 @@ The MPU also allows for an _application level programmers’ model_ to be implem
 - disable unprivileged writes
 - make areas read-only for privileged and/or unprivileged code.
 
-Additionally, the MPU let's you configure if a region of memory can be executed from using the _eXecute Never capability_ (`XN`). In a [previous article](https://interrupt.memfault.com/blog/how-to-write-linker-scripts-for-firmware#section-definitions), we discussed how different regions of memory will hold code (_text_) and data. Sometimes arbitrary data (like a string from a `printf()` statement) can look like valid ARM instructions. A classic security vulnerability would be to find a way to execute this data as code, escalate privileges and harm the system or steal information. We'll explore this concept in more detail below.
+Additionally, the MPU let's you configure if a region of memory can be executed from using the _eXecute Never capability_ (`XN`). In a [previous article]({% post_url 2019-06-25-how-to-write-linker-scripts-for-firmware %}#section-definitions), we discussed how different regions of memory will hold code (_text_) and data. Sometimes arbitrary data (like a string from a `printf()` statement) can look like valid ARM instructions. A classic security vulnerability would be to find a way to execute this data as code, escalate privileges and harm the system or steal information. We'll explore this concept in more detail below.
 
 ## MPU registers
 
@@ -54,7 +54,7 @@ The MPU is configured using just five registers! A great way to build an underst
 `MPU_TYPE` - Address 0xE000ED90 register bit assignments:
 ![](/img/armv7m_mpu/mpu_type.png)
 
-This register is present regardless of whether or not the MPU was implemented on the _Cortex-M_ device being used. This is pretty nice because it allows us to dynamically determine at runtime or via a [GDB Python script](https://interrupt.memfault.com/blog/automate-debugging-with-gdb-python-api) whether or not an MPU is present and use it. The **only** field of interest here is `DREGION` which reveals the number of MPU regions which were implemented. A value of 0 for `DREGION` indicates the MPU was not implemented.
+This register is present regardless of whether or not the MPU was implemented on the _Cortex-M_ device being used. This is pretty nice because it allows us to dynamically determine at runtime or via a [GDB Python script]({% post_url 2019-07-02-automate-debugging-with-gdb-python-api %}) whether or not an MPU is present and use it. The **only** field of interest here is `DREGION` which reveals the number of MPU regions which were implemented. A value of 0 for `DREGION` indicates the MPU was not implemented.
 
 ### MPU Control Register
 
@@ -208,7 +208,7 @@ int recursive_sum(int n) {
 
 From our `main` loop let's call `recursive_sum(600)`. If you compile and run the application, you should see the LEDs blink in a loop. Things _appear_ to be working. Let's use MPU Region 0 just to be sure we aren't overflowing our stack.
 
-The NRF52 SDK defines a [linker script variable](https://interrupt.memfault.com/blog/how-to-write-linker-scripts-for-firmware#variables), `__StackLimit`, which can be used to determine where the end of the stack is. We'll set up a `64 byte` MPU region at the bottom of the stack so we can catch a stack overflow as it is happening. Based on what we learned above, the configuration settings we need to add to our code will look something like:
+The NRF52 SDK defines a [linker script variable]({% post_url 2019-06-25-how-to-write-linker-scripts-for-firmware %}#variables), `__StackLimit`, which can be used to determine where the end of the stack is. We'll set up a `64 byte` MPU region at the bottom of the stack so we can catch a stack overflow as it is happening. Based on what we learned above, the configuration settings we need to add to our code will look something like:
 
 ```c
   volatile uint32_t *mpu_rbar = (void *)0xE000ED9C;

--- a/_posts/2019-07-30-bluetooth-low-energy-a-primer.md
+++ b/_posts/2019-07-30-bluetooth-low-energy-a-primer.md
@@ -222,7 +222,7 @@ Let's go through the different steps for downloading the necessary software pack
 
 For each of these downloads, you can place them anywhere on your machine. I recommend having them all in a single folder, to make it easier to locate later on.
 
-If you've read and followed the steps in our previous post [*Debugging Firmware with GDB*](https://interrupt.memfault.com/blog/gdb-for-firmware-1), you would already have all the necessary software packages installed and set up (and you could safely skip the installation section).
+If you've read and followed the steps in our previous post [*Debugging Firmware with GDB*]({% post_url 2019-05-21-gdb-for-firmware-1 %}), you would already have all the necessary software packages installed and set up (and you could safely skip the installation section).
 
 #### 1. nRF5 SDK
 Installation of the nRF5 SDK is straightforward. All you need to do is download the SDK tarball from Nordic's website and then extract it.

--- a/_posts/2019-08-06-a-deep-dive-into-arm-cortex-m-debug-interfaces.md
+++ b/_posts/2019-08-06-a-deep-dive-into-arm-cortex-m-debug-interfaces.md
@@ -132,7 +132,7 @@ Now that we understand a bit about the software stack in play. Let's trace throu
 
 For this setup we will use:
 
-- A nRF52840-DK running the blinky demo application from our [MPU blog post](https://interrupt.memfault.com/blog/fix-bugs-and-secure-firmware-with-the-mpu#mpu-usage-examples)
+- A nRF52840-DK running the blinky demo application from our [MPU blog post]({% post_url 2019-07-16-fix-bugs-and-secure-firmware-with-the-mpu %}#mpu-usage-examples)
 - A saleae logic analyzer[^18]
 
 ## Debug Path

--- a/_posts/2019-08-13-how-to-write-a-bootloader-from-scratch.md
+++ b/_posts/2019-08-13-how-to-write-a-bootloader-from-scratch.md
@@ -624,6 +624,8 @@ or at [interrupt@memfault.com](mailto:interrupt@memfault.com).
 
 Next time in the series, we'll talk about bootstrapping the C library!
 
+_EDIT: Post written!_ - [Bootstrapping libc with Newlib]({% post_url 2019-11-12-boostrapping-libc-with-newlib %})
+
 _Like Interrupt? [Subscribe](http://eepurl.com/gpRedv) to get our latest
 posts straight to your mailbox_
 

--- a/_posts/2019-09-04-arm-cortex-m-exceptions-and-nvic.md
+++ b/_posts/2019-09-04-arm-cortex-m-exceptions-and-nvic.md
@@ -88,7 +88,7 @@ reserve **Exception Numbers** **1**-**15**, inclusive, for these.
 Six exceptions are always supported and depending on the Cortex-M variant, additional
 handlers will be implemented as well. The minimum set is:
 
-- **Reset** - This is the routine executed when a chip comes out of reset. More details can be found within the zero-to-main bootloader series of [posts](https://interrupt.memfault.com/blog/tag/zero-to-main).
+- **Reset** - This is the routine executed when a chip comes out of reset. More details can be found within the [Zero to main() series of posts]({{ '/tag/zero-to-main' | relative_url  }}).
 - **Non Maskable Interrupt** (`NMI`) - As the name implies, this interrupt cannot be disabled. If
   errors happen in other exception handlers, a NMI will be triggered. Aside from the `Reset`
   exception, it has the highest priority of all exceptions.
@@ -756,7 +756,7 @@ that I've found to be interesting:
 
 ## Reference Links
 
-[^1]: [MPU overview](https://interrupt.memfault.com/blog/fix-bugs-and-secure-firmware-with-the-mpu)
+[^1]: [MPU overview]({% post_url 2019-07-16-fix-bugs-and-secure-firmware-with-the-mpu %})
 [^3]: [See "Overview of the exceptions supported" section](https://static.docs.arm.com/ddi0403/eb/DDI0403E_B_armv7m_arm.pdf)
 [^4]: [ARMv7-M Specification](https://static.docs.arm.com/ddi0403/eb/DDI0403E_B_armv7m_arm.pdf)
 [^5]: [ARM Architecture Procedure Calling Standard (AAPCS)](http://infocenter.arm.com/help/topic/com.arm.doc.ihi0042f/IHI0042F_aapcs.pdf)

--- a/_posts/2019-09-17-continuous-integration-for-firmware.md
+++ b/_posts/2019-09-17-continuous-integration-for-firmware.md
@@ -6,7 +6,7 @@ tags: [better-firmware]
 ---
 
 Larger firmware projects sometimes have tens, even hundreds of engineers working
-in a single codebase. This introduces new challenges: builds break, lesser used
+in a single code base. This introduces new challenges: builds break, lesser used
 features get forgotten about, new features miss support for older hardware
 platforms. Without solid tooling and processes, this can slow development to a
 grind.
@@ -24,7 +24,7 @@ CircleCI on a firmware project step by step.
 
 <!-- excerpt end -->
 
-This is the first post in our _Building Better Firmware_ series. Future posts will
+This is the first post in our [Building Better Firmware series]({{ '/tag/better-firmware' | relative_url }}). Future posts will
 cover testing techniques, test driven development, fuzzing, and continuous
 deployment.
 

--- a/_posts/2019-09-24-ble-throughput-primer.md
+++ b/_posts/2019-09-24-ble-throughput-primer.md
@@ -14,6 +14,8 @@ In this article, we dive into the factors which influence BLE throughput. We wil
 
 <!-- excerpt end -->
 
+I recommend starting with our [Primer on Bluetooth Low Energy]({% post_url 2019-07-30-bluetooth-low-energy-a-primer %}) if this is your first time working with BLE.
+
 _Like Interrupt? [Subscribe](http://eepurl.com/gpRedv) to get our latest
 posts straight to your mailbox_
 
@@ -118,7 +120,7 @@ Below is a diagram of the layout of an L2CAP packet. As you can see there are 4 
 In the _L2CAP Information Payload_ we have the ATT packet. This is the packet structure the _GATT_
 protocol uses.
 
-> NOTE: For an excellent article about GATT itself, check out Mohammad Afaneh's thorough [BLE Primer post](https://interrupt.memfault.com/blog/bluetooth-low-energy-a-primer) on the topic!
+> NOTE: For an excellent article about GATT itself, check out Mohammad Afaneh's thorough [BLE Primer post]({% post_url 2019-07-30-bluetooth-low-energy-a-primer %}) on the topic!
 
 ATT packets can span multiple LL packets. The size of the data unit within an ATT packet is known
 as the _Maximum Transmission Unit_ (**MTU**). The default size is 23 bytes (which allows the packet
@@ -370,6 +372,6 @@ presentation provides an excellent overview of how to get the most out of iOS Co
 [^7]: [ Accessory Design Guidelines for Apple Devices](https://developer.apple.com/accessories/Accessory-Design-Guidelines.pdf)
 [^8]: [Reddit comment about Nordic's BLE sniffer](https://www.reddit.com/r/embedded/comments/d95obo/a_practical_guide_to_ble_throughput/f1f0q68/)
 [^9]: [nRF Sniffer For Bluetooth LE](https://www.nordicsemi.com/Software-and-Tools/Development-Tools/nRF-Sniffer-for-Bluetooth-LE)
-[^10]: [More details about GATT Operations](https://interrupt.memfault.com/blog/bluetooth-low-energy-a-primer#services-and-characteristics)
+[^10]: [More details about GATT Operations]({% post_url 2019-07-30-bluetooth-low-energy-a-primer %}#services-and-characteristics)
 [^11]: See "3.2.9 Long Attribute Values" of the [Bluetooth 5.1 Core Specification](https://www.bluetooth.com/specifications/bluetooth-core-specification/)
 [^12]: See comment from _/u/writtenabode_ on [Reddit](https://www.reddit.com/r/embedded/comments/d95obo/a_practical_guide_to_ble_throughput/f22udsz/) and _oflannabhra_ on [HN](https://news.ycombinator.com/item?id=21082583)

--- a/_posts/2019-10-22-best-and-worst-gcc-clang-compiler-flags.md
+++ b/_posts/2019-10-22-best-and-worst-gcc-clang-compiler-flags.md
@@ -552,7 +552,7 @@ You can find all the details about optimization flags in the "Optimization Optio
 GNU GCC docs[^5]. `-Os`, optimize for size, is generally the optimization flag you will see used
 for embedded systems. It enables a good balance of flags which optimize for size _as well as
 speed_. Forgetting to flip on this flag can have serious code size impacts. For more details check
-out the [interrupt series](https://interrupt.memfault.com/blog/tag/fw-code-size) of posts about it!
+out the [interrupt series]({{ '/tag/fw-code-size' | relative_url  }}) of posts about it!
 
 ### \-ffunction-sections, \-fdata-sections, & \-\-gc-sections
 
@@ -899,7 +899,7 @@ See anything you'd like to change? Submit a pull request or open an issue at
 [^11]: [-Wformat Option Documentation](https://gcc.gnu.org/onlinedocs/gcc-8.3.0/gcc/Warning-Options.html#index-Wformat)
 [^12]: [See format attribute](https://gcc.gnu.org/onlinedocs/gcc-8.3.0/gcc/Common-Function-Attributes.html#Common-Function-Attributes)
 [^13]: [See "7.1.3 Enumerated Types"](http://infocenter.arm.com/help/topic/com.arm.doc.ihi0042f/IHI0042F_aapcs.pdf)
-[^14]: [Demystifying Firmware Linker Scripts](https://interrupt.memfault.com/blog/how-to-write-linker-scripts-for-firmware)
-[^15]: [Linker Garbage Collection](https://interrupt.memfault.com/blog/code-size-optimization-gcc-flags#linker-garbage-collection)
+[^14]: [Demystifying Firmware Linker Scripts]({% post_url 2019-06-25-how-to-write-linker-scripts-for-firmware %})
+[^15]: [Linker Garbage Collection]({% post_url 2019-08-20-code-size-optimization-gcc-flags %}#linker-garbage-collection)
 [^16]: [-ffast-math documentation](https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#index-ffast-math)
 [^17]: [See "6.3 Conversions" for "integer promotion" & "arithmetic conversion" rules](http://www.open-std.org/jtc1/sc22/wg14/www/docs/n1570.pdf)

--- a/_posts/2019-10-30-cortex-m-rtos-context-switching.md
+++ b/_posts/2019-10-30-cortex-m-rtos-context-switching.md
@@ -216,7 +216,7 @@ pointer which is used can be controlled in two ways:
 ### Context State Stacking
 
 In our
-[guide](https://interrupt.memfault.com/blog/arm-cortex-m-exceptions-and-nvic#exception-entry--exit)
+[guide]({% post_url 2019-09-04-arm-cortex-m-exceptions-and-nvic %}#exception-entry--exit)
 about ARM Cortex-M Exception Handling, we touched upon how the hardware itself implements the AAPCS[^1]
 so that interrupts can be implemented as normal C functions. Here we will expand on what that
 actually means.
@@ -356,7 +356,7 @@ task needs to be preserved in some way. This includes information such as the ex
 (i.e blocked on a mutex, sleeping, etc) and the values of the active hardware registers.
 
 As we alluded to in our
-[ARM Cortex-M Exception](https://interrupt.memfault.com/blog/arm-cortex-m-exceptions-and-nvic#built-in-exceptions)
+[ARM Cortex-M Exception]({% post_url 2019-09-04-arm-cortex-m-exceptions-and-nvic %}#built-in-exceptions)
 article, the `SVCall`, `PendSV`, and `SysTick` interrupts integrated into every Cortex-M device
 were explicitly designed to make task management simple. Consequently, the context switching logic
 winds up looking extremely similar regardless of the RTOS in use. So if you understand how one

--- a/_posts/2019-11-12-boostrapping-libc-with-newlib.md
+++ b/_posts/2019-11-12-boostrapping-libc-with-newlib.md
@@ -26,7 +26,7 @@ int main() {
   while (1) {}
 }
 ```
-Compiling this using our makefile and linker script from [previous]({% post_url
+Compiling this using our Makefile and linker script from [previous]({% post_url
 2019-05-14-zero-to-main-1 %}) [posts]({% post_url
 2019-06-25-how-to-write-linker-scripts-for-firmware %}), we hit
 the following error:
@@ -73,7 +73,7 @@ board to run our examples. We use a cheap CMSIS-DAP adapter and openOCD to
 program it.
 
 You can find a step by step guide [in our previous
-post](https://interrupt.memfault.com/blog/getting-started-with-ibdap-and-atsamd21g18).
+post]({% post_url 2019-04-25-getting-started-with-ibdap-and-atsamd21g18 %}).
 
 As with previous examples, we start with our “minimal” example which you can
 find [on GitHub](https://github.com/memfault/zero-to-main/tree/master/minimal).
@@ -125,7 +125,7 @@ Today Newlib is bundled alongside toolchains and SDK provided by vendors such as
 > features, and some `printf` bells and whistles to deliver a more compact
 > standard library. Newlib-nano is enabled with the `—specs=nano.specs` CFLAG.
 > You can read more about it in our [code size blog
-> post](https://interrupt.memfault.com/blog/code-size-optimization-gcc-flags#c-library)  
+> post]({% post_url 2019-08-20-code-size-optimization-gcc-flags %}#c-library)
 
 ### Enabling Newlib
 
@@ -390,7 +390,7 @@ void *_sbrk(int incr) {
 More often than not, we want the heap to use all the RAM not used by anything
 else. We therefore set `HEAP_START` to the first address not spoken for in our
 linker script. In our [previous
-post](https://interrupt.memfault.com/blog/how-to-write-linker-scripts-for-firmware#complete-linker-script),
+post]({% post_url 2019-06-25-how-to-write-linker-scripts-for-firmware %}#complete-linker-script),
 we had added the `_end` variable in our linker script to that end.
 
 We replace `HEAP_START` with `_end` and get:
@@ -720,13 +720,15 @@ include ../common-standalone.mk
 
 We hope reading this post has given you an understanding of how standard C
 functions come to be available in firmware code. As with previous posts,
-code examples are available on Github in the [zero to main
+code examples are available in the [Zero to Main Github
 repository](https://github.com/memfault/zero-to-main).
 
 Got a favorite libc implementation? Tell us all about it in the comments,
 or at [interrupt@memfault.com](mailto:interrupt@memfault.com).
 
 Next time in the series, we'll talk about Rust!
+
+_EDIT: Post written!_ - [From Zero to main(): Bare metal Rust]({% post_url 2019-12-17-zero-to-main-rust-1 %})
 
 _Like Interrupt? [Subscribe](http://eepurl.com/gpRedv) to get our latest
 posts straight to your mailbox_

--- a/_posts/2019-12-11-reproducible-firmware-builds.md
+++ b/_posts/2019-12-11-reproducible-firmware-builds.md
@@ -139,7 +139,7 @@ Now when we start the application, we crash on boot. How strange!
 
 ### Why does only one of the builds crash?!
 
-A full discussion of how to debug the crash is outside the scope of this article but can be found in [this post](https://interrupt.memfault.com/blog/cortex-m-fault-debug#debugger-plugins).
+A full discussion of how to debug the crash is outside the scope of this article but can be found in [this post]({% post_url 2019-11-20-cortex-m-fault-debug %}#debugger-plugins).
 
 We examine the Configurable Fault Status Register (CFSR) and can see that a UsageFault has taken place:
 
@@ -352,7 +352,7 @@ $ sdiff -s <(xxd repos/interrupt/example/reproducible-build/build/nrf52.bin) <(x
 00000060: 63e7 2d9c a9c9 0aa4 38f4 9b54 0000 0000  c.-.....8. |	00000060: 5deb df50 e138 ff64 174c 6e12 0000 0000  ]..P.8.d.L
 ```
 
-The "GNU" in the string in this case stands out. That's likely from the [GNU Build ID](https://interrupt.memfault.com/blog/gnu-build-id-for-firmware) we are using in the firmware to _uniquely_ identify the compilation.
+The "GNU" in the string in this case stands out. That's likely from the [GNU Build ID]({% post_url 2019-05-29-gnu-build-id-for-firmware %}) we are using in the firmware to _uniquely_ identify the compilation.
 
 The GNU Build ID is a SHA computed over the binary sections _as well as_ the debug sections in an ELF.
 
@@ -450,7 +450,7 @@ In summary, here are the steps to take in order to make a build reproducible:
 
 First, compile your binary in two directories. If the binaries match, you are probably good! Otherwise, follow these strategies:
 
-1. Include a [GNU Build ID](https://interrupt.memfault.com/blog/gnu-build-id-for-firmware) in your binary so it's always easy to identify the build in use.
+1. Include a [GNU Build ID]({% post_url 2019-05-29-gnu-build-id-for-firmware %}) in your binary so it's always easy to identify the build in use.
 2. [Enforce that all builds use one version of a compiler](#enforce-compiler-for-build).
 3. Compare ELFs and BINs for differences using the tips discussed in this article. Typical differences arise from including absolute paths, timestamps, or shell information in the final binary.
 4. Utilize [`-fdebug-prefix-map=old=new`](#fdebug-prefix-map) to make sure any debug information emitted does not rely on absolute paths.
@@ -465,7 +465,7 @@ Over a projects lifetime, you will likely wind up making changes to the product 
 1. Migrating to a new build system (i.e Make to CMake)
 2. Refactoring a Makefile to be more readable
 3. Sorting headers in a C file to follow a coding convention
-4. Fixing a new [compiler warning](https://interrupt.memfault.com/blog/best-and-worst-gcc-clang-compiler-flags#the-best-one-off-warning-options-options-not-covered-by--wall-or--wextra) that shouldn't impact the binary produced.
+4. Fixing a new [compiler warning]({% post_url 2019-10-22-best-and-worst-gcc-clang-compiler-flags %}#the-best-one-off-warning-options-options-not-covered-by--wall-or--wextra) that shouldn't impact the binary produced.
 5. Refactoring a linker script so it's easier to extend
 
 Some of these parts of a codebase can be "scary" ones to touch. By applying what we have learned above to debug how binaries differ, we can make these types of changes with confidence ... if we update a Makefile and don't expect a change in the binary but something _has_ changed, it likely means we have messed up! Let's walk through a quick example.
@@ -574,7 +574,7 @@ or by dumping it in GDB:
 65                "Ping", configMINIMAL_STACK_SIZE,
 ```
 
-Per the [ARM procedure call standard](https://interrupt.memfault.com/blog/cortex-m-rtos-context-switching#core-registers), `$r0` is used to hold the first argument for a function call. This means that the `$r0` operation we see above maps to `MAIN_QUEUE_LENGTH`. But how did that change between builds? Let's grep[^6] through the codebase to see where it is defined.
+Per the [ARM procedure call standard]({% post_url 2019-10-30-cortex-m-rtos-context-switching %}#core-registers), `$r0` is used to hold the first argument for a function call. This means that the `$r0` operation we see above maps to `MAIN_QUEUE_LENGTH`. But how did that change between builds? Let's grep[^6] through the codebase to see where it is defined.
 
 ```bash
 $rg "define.*MAIN_QUEUE_LENGTH"
@@ -593,7 +593,7 @@ Oh interesting, the define is provided in two headers. In `main.c` we just inclu
 
 ## Closing
 
-I hope this post gave you a useful overview of the benefits of reproducible builds and how you might update your project to achieve this behavior
+I hope this post gave you a useful overview of the benefits of reproducible builds and how you might update your project to achieve this behavior.
 
 Are the builds for your project reproducible today? Are there other matters on the topic that you would have liked to see us cover? Let us know in the discussion area below!
 

--- a/_posts/2019-12-17-zero-to-main-rust-1.md
+++ b/_posts/2019-12-17-zero-to-main-rust-1.md
@@ -21,7 +21,7 @@ As a compiled systems language (based on LLVM), it is also capable of reaching d
 
 This post is meant as a complement to the original [Zero to main()] post on the Interrupt blog, and will elide some of the explanations of hardware level concepts. If you're new to embedded development, or haven't seen that post, go read it now!
 
-[Zero to Main()]: https://interrupt.memfault.com/blog/zero-to-main-1
+[Zero to Main()]: {% post_url 2019-05-14-zero-to-main-1 %}
 
 ## Setting the stage
 

--- a/_posts/2020-01-07-conda-developer-environments.md
+++ b/_posts/2020-01-07-conda-developer-environments.md
@@ -15,7 +15,7 @@ longer installed. This can be a major pain, and people have come up with several
 ways around it.
 
 In previous posts,
-[we have used virtualenv](https://interrupt.memfault.com/blog/using-pypi-packages-with-GDB#virtual-environment)
+[we have used virtualenv]({% post_url 2019-07-23-using-pypi-packages-with-GDB %}#virtual-environment)
 to manage our Python packages. What if you would like to easily manage non
 Python dependencies? This is where Conda comes into play.
 

--- a/_posts/2020-02-04-rust-for-digital-signal-processing.md
+++ b/_posts/2020-02-04-rust-for-digital-signal-processing.md
@@ -8,7 +8,7 @@ image: /img/rust-dsp/rust-dsp-code.png
 
 Like many firmware developers, I've been curious about the potential Rust can
 have in the embedded space. After reading James Munns' [great
-article](https://interrupt.memfault.com/blog/zero-to-main-rust-1), I decided to
+article]({% post_url 2019-12-17-zero-to-main-rust-1 %}), I decided to
 find a project I could use Rust for to learn.
 
 We're still in the early days of Rust on embedded. Given all the chipset SDKs
@@ -504,10 +504,10 @@ straight to your mailbox_
 
 ## References
 
-[^1]: [Rust and the panic behavior](https://interrupt.memfault.com/blog/zero-to-main-rust-1#something-just-for-rust)
+[^1]: [Rust and the panic behavior]({% post_url 2019-12-17-zero-to-main-rust-1 %}#something-just-for-rust)
 [^2]: [A little Rust with your C](https://rust-embedded.github.io/book/interoperability/rust-with-c.html)
 [^3]: [Optimize Rust for speed](https://rust-embedded.github.io/book/unsorted/speed-vs-size.html#optimize-for-speed)
-[^4]: [Code Size Optimization: GCC Compiler Flags](https://interrupt.memfault.com/blog/code-size-optimization-gcc-flags#changing-the-optimization-level)
+[^4]: [Code Size Optimization: GCC Compiler Flags]({% post_url 2019-08-20-code-size-optimization-gcc-flags %}#changing-the-optimization-level)
 [^5]: [Cycle Count register](http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.ddi0439b/BABJFFGJ.html)
 [^6]: [Issue: Ability to set crate-type depending on target](https://github.com/rust-lang/cargo/issues/4881)
 [^7]: [Command-line apps with Rust](https://www.rust-lang.org/what/cli)

--- a/_posts/2020-02-11-improving-compilation-times-c-cpp-projects.md
+++ b/_posts/2020-02-11-improving-compilation-times-c-cpp-projects.md
@@ -103,7 +103,7 @@ isn't satisfied, I'd start there.
   as the linking step sometimes becomes as slow as the entire build itself! If
   you have enabled it due to code size constraints, I suggest checking out
   Interrupt's
-  [code size posts](https://interrupt.memfault.com/blog/tag/fw-code-size) for
+  [code size posts]({{ '/tag/fw-code-size' | relative_url  }}) for
   easy wins.
 
 ## Example Build Environment


### PR DESCRIPTION
When we were originally writing posts for Interrupt, we left a lot of
breadcrumbs like "In a future post...". Now that we've been at it for a
while, we've written a lot of these posts, so I've went ahead and added
links between most of the posts and to series (tags).

Also, while I'm at it, remove all hard-coded interrupt.memfault.com links
and change them to use `post_url` since these are harder to test.

Test Plan:
- Mostly go over the diff by hand/eyes
- Go through each post and make sure the links that I've edited render
  correctly and properly link to another page.