### PR TITLE
Add Author pages that show the short bio and posts

### DIFF
--- a/_includes/author-social.html
+++ b/_includes/author-social.html
@@ -1,0 +1,12 @@
+{% assign author = include.author %}
+<span>
+    {% if author.twitter %}
+    <a href="https://twitter.com/{{ author.twitter }}"><svg class="svg-icon twitter"><use xlink:href="{{ 'img/social-icons.svg#twitter' | relative_url }}"></use></svg></a>
+    {% endif %}
+    {% if author.linkedin %}
+    <a href="{{ author.linkedin }}"><svg class="svg-icon linkedin"><use xlink:href="{{ 'img/social-icons.svg#linkedin' | relative_url }}"></use></svg></a>
+    {% endif %}
+    {% if author.github %}
+    <a href="https://github.com/{{ author.github }}"><svg class="svg-icon github"><use xlink:href="{{ 'img/social-icons.svg#github' | relative_url }}"></use></svg></a>
+    {% endif %}
+</span>

--- a/_layouts/author.html
+++ b/_layouts/author.html
@@ -1,0 +1,16 @@
+---
+layout: default
+---
+<article id="author-page">
+    <h2><a href="{{ page.author.web }}">{{ page.author.name }}</a></h2>
+    {% include author-social.html author=page.author %}
+    <br>
+    {{ page.author.name }} {{ page.author.blurb }}
+    <h3>Posts</h3>
+        {% assign filtered_posts = site.posts | where: 'author', page.author_key %}
+
+        {% for post in filtered_posts %}
+        <li>{{ post.date | date_to_string }} - <a href="{{ post.url }}">{{ post.title }}</a></li>
+        {% endfor %}
+    <br>
+</article>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -3,13 +3,14 @@ layout: default
 ---
 <article id="post-page">
     {% assign author = site.data.authors[page.author] %}
+    {% assign author_key = page.author %}
 
     <script src="/js/anchor.min.js"></script>
     <h2>{{ page.title }}</h2>
     <div class="by-line">
        <time datetime="{{ page.date | date_to_xmlschema }}">{{ page.date | date_to_string }}</time>
        {% if author %}
-       <span>by <a href="{{ author.web }}">{{ author.name }}</a></span>
+       <span>by <a href="/authors/{{ author_key }}">{{ author.name }}</a></span>
        {% endif %}
     </div>
     <div class="content">
@@ -24,16 +25,8 @@ layout: default
             <img src="{{ author.image | prepend: site.baseurl | replace: '//', '/' }}"  />
             {% endif %}
             <span>
-                <a href="{{ author.web }}">{{ author.name }}</a> {{ author.blurb }}<br />
-                {% if author.twitter %}
-                <a href="https://twitter.com/{{ author.twitter }}"><svg class="svg-icon twitter"><use xlink:href="{{ 'img/social-icons.svg#twitter' | relative_url }}"></use></svg></a>
-                {% endif %}
-                {% if author.linkedin %}
-                <a href="{{ author.linkedin }}"><svg class="svg-icon linkedin"><use xlink:href="{{ 'img/social-icons.svg#linkedin' | relative_url }}"></use></svg></a>
-                {% endif %}
-                {% if author.github %}
-                <a href="https://github.com/{{ author.github }}"><svg class="svg-icon github"><use xlink:href="{{ 'img/social-icons.svg#github' | relative_url }}"></use></svg></a>
-                {% endif %}
+                <a href="/authors/{{ author_key }}">{{ author.name }}</a> {{ author.blurb }}<br />
+                {% include author-social.html author=author %}
             </span>
 
         </div>

--- a/_plugins/authors.rb
+++ b/_plugins/authors.rb
@@ -1,0 +1,26 @@
+module Jekyll
+  class AuthorPageGenerator < Generator
+    safe true
+
+    def generate(site)
+      site.data['authors'].each do |author_key, author|
+        site.pages << AuthorPage.new(site, site.source, author_key, author)
+      end
+    end
+  end
+
+  class AuthorPage < Page
+    def initialize(site, base, author_key, author)
+      @site = site
+      @base = base
+      @dir  = File.join('authors', author_key)
+      @name = 'index.html'
+
+      self.process(@name)
+      self.read_yaml(File.join(base, '_layouts'), 'author.html')
+      self.data['author'] = author
+      self.data['author_key'] = author_key
+      self.data['title'] = "Author: #{author_key}"
+    end
+  end
+end

--- a/authors.html
+++ b/authors.html
@@ -1,0 +1,17 @@
+---
+layout: page
+title: Authors
+---
+
+<ul>
+  {% for author in site.data.authors %}
+    <h2><a href="/authors/{{ author[0] }}">{{ author[1].name }}</a></h2>
+    <ul>
+      {% assign filtered_posts = site.posts | where: 'author', author[0] %}
+      {% for post in filtered_posts %}
+        <li><a href="{{ post.url }}">{{ post.title }}</a></li>
+      {% endfor %}
+    </ul>
+  {% endfor %}
+</ul>
+

--- a/index.html
+++ b/index.html
@@ -11,8 +11,9 @@ layout: default
         <div class="by-line">
             <time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date_to_string }}</time>
             {% assign author = site.data.authors[post.author] %}
+            {% assign author_key = post.author %}
             {% if author %}
-            <span>by <a href="{{ author.web }}">{{ author.name }}</a></span>
+            <span>by <a href="/authors/{{ author_key }}">{{ author.name }}</a></span>
             {% endif %}
         </div>
         <p>{{ post.excerpt }}</p>


### PR DESCRIPTION
I love Chris and Francois' posts, and I want a way to read all of them
easier.

```
/authors - All authors and posts page
/authors/<author_id> - Individual author page
```