### PR TITLE
fix markup typo in 2020-06-09-firmware-shell.md

### DIFF
--- a/_posts/2020-06-09-firmware-shell.md
+++ b/_posts/2020-06-09-firmware-shell.md
@@ -655,7 +655,7 @@ I won't go very deep in this section, but I do want to give a rough idea of how
 one would implement unit tests for a shell.
 
 Using CppUTest and a similar structure to our previous [Unit Testing
-Basics]({% post_url 2019-10-08-unit-testing-basics %} post, we arrive at the
+Basics]({% post_url 2019-10-08-unit-testing-basics %}) post, we arrive at the
 following structure within our `part2/` example:
 
 ```


### PR DESCRIPTION
I think you missed this closing brace in the markup for a link  (thanks for the great article!)