### PR TITLE
Improving theme

### DIFF
--- a/_sass/layout.scss
+++ b/_sass/layout.scss
@@ -265,7 +265,6 @@ footer {
   text-align: center;
   padding: 0.6667em 0;
   text-align: center;
-  position: absolute;
   width: 100%;
   bottom: 0;
 }
@@ -273,7 +272,6 @@ footer {
 #wrap {
 	min-height:100%;
 	position:relative;
-	padding-bottom: 105px;
 }
 
 .footer-links {

--- a/_sass/layout.scss
+++ b/_sass/layout.scss
@@ -7,7 +7,7 @@ html, body {
 
 /* Navigation */
 
-#nav, #nav-left { 
+#nav, #nav-left {
   a {
     display: block;
     color: $background-color;
@@ -248,7 +248,9 @@ code {
   color: $background-color;
   padding: 4px 8px;
   font-weight: 400;
-  padding: 0.5em 1em;
+	display: inline-block;
+	margin-bottom: 0.5em;
+  padding: 0.2em 1em;
   -webkit-border-radius: 4px;
      -moz-border-radius: 4px;
       -ms-border-radius: 4px;
@@ -269,7 +271,7 @@ footer {
 }
 
 #wrap {
-	min-height:100%; 
+	min-height:100%;
 	position:relative;
 	padding-bottom: 105px;
 }

--- a/_sass/tag.scss
+++ b/_sass/tag.scss
@@ -31,9 +31,9 @@
   .tags-expo-list {
     @media (min-width: 38em) {
       font-size: 0.9rem;
-      .post-tag {
-        margin: .2em .3em;
-      }
+    }
+    .post-tag {
+      margin: .2em .3em;
     }
   }
   .tags-expo-section {


### PR DESCRIPTION
### Contribution description
The following PR aims to improve several sections at Interrupt Blog which I list below: 

- **Pagination items**
Up to now, if some relentless embedded engineer wants to dive into one of your great articles probably will end it up using the pagination tool, however, when this is made at small screens this is what we have:

![image](https://user-images.githubusercontent.com/1287883/89132468-c291eb00-d4ea-11ea-89d1-f5f9068c37d5.png)

I propose to change the css a little bit to provide enough space having this instead: 

![image](https://user-images.githubusercontent.com/1287883/89132487-f0772f80-d4ea-11ea-81e4-8804e11588e1.png)

- **Space between tags**
I suggest to increase the space between tags when is viewed from small screens, what we have right now is: 

![image](https://user-images.githubusercontent.com/1287883/89132533-46e46e00-d4eb-11ea-8190-2613c0e2708d.png)

But we can have this:
![image](https://user-images.githubusercontent.com/1287883/89132550-62e80f80-d4eb-11ea-9bd4-8307b6d5a70c.png)


- **Footer overlapping main content**
From small screens as well I noticed that footer gets in the middle at the bottom of main content. See the following: 

![image](https://user-images.githubusercontent.com/1287883/89132595-b9ede480-d4eb-11ea-86db-460bcc684c12.png)

We can add a little modification on code to separate footer and main content as it follows:

![image](https://user-images.githubusercontent.com/1287883/89132626-f3beeb00-d4eb-11ea-9f54-00a6a1a3b254.png)





