### PR TITLE
Reuse submit PR and newsletter, set color box in TOC. 

### DIFF
--- a/_drafts/_template.md
+++ b/_drafts/_template.md
@@ -1,13 +1,13 @@
 ---
 # This is a template for Interrupt posts. Use previous, more recent posts from the _posts/
 # directory for more inspiration and patterns.
-# 
+#
 # When submitting a post for publishing, submit a PR with the post in the _drafts/ directory
 # and it will be moved to _posts/ on the date of publish.
-# 
+#
 # e.g.
-# $ cp _drafts/_template.md _drafts/my_post.md 
-# 
+# $ cp _drafts/_template.md _drafts/my_post.md
+#
 # It will now show up in the front page when running Jekyll locally.
 
 title: Post Title
@@ -27,8 +27,7 @@ Excerpt Content
 
 Optional motivation to continue onwards
 
-_Like Interrupt? [Subscribe](http://eepurl.com/gpRedv) to get our latest posts
-straight to your mailbox_
+{% include newsletter.html %}
 
 {:.no_toc}
 
@@ -45,11 +44,9 @@ straight to your mailbox_
 
 
 <!-- Interrupt Keep START -->
-_Like Interrupt? [Subscribe](http://eepurl.com/gpRedv) to get our latest posts
-straight to your mailbox_
+{% include newsletter.html %}
 
-See anything you'd like to change? Submit a pull request or open an issue at
-[GitHub](https://github.com/memfault/interrupt)
+{% include submit-pr.html %}
 <!-- Interrupt Keep END -->
 
 {:.no_toc}

--- a/_includes/newsletter.html
+++ b/_includes/newsletter.html
@@ -1,0 +1,3 @@
+<div class="newsletter">
+  <p class="newsletter-content">Like Interrupt? <a class="newsletter-link" href="http://eepurl.com/gpRedv" target="_blank">Subscribe</a> to get our latest posts straight to your mailbox.</p>
+</div>

--- a/_includes/submit-pr.html
+++ b/_includes/submit-pr.html
@@ -1,0 +1,3 @@
+<div class="submit-pr">
+  <p class="submit-pr-content">See anything you'd like to change? Submit a pull request or open an issue at <a class="submit-pr-link" href="https://github.com/memfault/interrupt" target="_blank">GitHub</a></p>
+</div>

--- a/_posts/2019-05-14-zero-to-main-1.md
+++ b/_posts/2019-05-14-zero-to-main-1.md
@@ -206,7 +206,7 @@ This mirrors what the C standards tells us:
 
 > All objects with static storage duration shall be initialized (set to their
 > initial values) before program startup. The manner and timing of such
-> initialization are otherwise unspecified. 
+> initialization are otherwise unspecified.
 
 (Section 5.1.2, Execution environment)
 
@@ -314,9 +314,8 @@ Nordic](https://github.com/NordicSemiconductor/nrfx/blob/6f54f689e9555ea18f9aca8
 
 ## Closing
 
-All the code used in this blog post is available on 
-[Github](https://github.com/memfault/zero-to-main/tree/master/minimal). See
-anything you'd like to change? Submit a pull request!
+All the code used in this blog post is available on
+[Github](https://github.com/memfault/zero-to-main/tree/master/minimal). {% include submit-pr.html %}
 
 More complex programs often require a more complicated `Reset_Handler`. For
 example:
@@ -325,8 +324,8 @@ example:
   _EDIT: Post written!_ - [From Zero to main(): Bootstrapping libc with Newlib]({% post_url 2019-11-12-boostrapping-libc-with-newlib %})
 3. More complex memory layouts can add a few copy / zero loops
 
-We'll cover all of them in future posts. But before that, 
-we'll talk about how the magical memory region variables come about, 
+We'll cover all of them in future posts. But before that,
+we'll talk about how the magical memory region variables come about,
 how our `Reset_Handler`'s address ends up at `0x00000004`, and how to write a
 linker script in our next post!
 

--- a/_posts/2019-05-21-gdb-for-firmware-1.md
+++ b/_posts/2019-05-21-gdb-for-firmware-1.md
@@ -38,9 +38,9 @@ GDB was developed by Richard Stallman in 1986 as part of the GNU system. It is o
 
 Some of the most important are:
 
-- GDB supports a vast number of architectures including: ARM, x86, MIPS, and many more. Because of this, a firmware developer's knowledge and expertise with GDB is potentially transferrable across many projects. 
+- GDB supports a vast number of architectures including: ARM, x86, MIPS, and many more. Because of this, a firmware developer's knowledge and expertise with GDB is potentially transferrable across many projects.
 - GDB is command-line based which gives it high flexibility and usability in debugging tasks that require some level of automation. This became especially true with the release of the Python API for GDB in GDB's release version 7.0 (in 2011).
-- GDB supports remote debugging. This is crucial for embedded systems where the development environment resides on an architecture different from the target system (e.g. developing on a Windows machine for an ARM-based target). 
+- GDB supports remote debugging. This is crucial for embedded systems where the development environment resides on an architecture different from the target system (e.g. developing on a Windows machine for an ARM-based target).
 
 Because of these reasons, we believe it is extremely helpful for a firmware developer to at least get **some** exposure to using GDB.
 
@@ -160,7 +160,7 @@ Once you've done that, go ahead and add the following lines to the bottom of the
 ```
 export PATH = "<Your Folder>/nRF-Command-Line-Tools_9_8_1_OSX/nrfjprog":$PATH
 export PATH = "<Your Folder>/gcc-arm-none-eabi-7-2017-q4-major/bin":$PATH
-``` 
+```
 
 Make sure to replace `<Your Folder>` with the appropriate folder name where you placed those packages on your system.
 
@@ -177,7 +177,7 @@ To verify, you can type the following command:
 ```terminal
 $ echo $PATH
 /usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Users/mafaneh/Memfault/nRF-Command-Line-Tools_9_8_1_OSX/nrfjprog:/Users/mafaneh/Memfault/gcc-arm-none-eabi-7-2017-q4-major/bin
-``` 
+```
 
 That's it for the setup part, now on to the fun part!
 
@@ -197,7 +197,7 @@ You'll notice there are many subfolders in that folder. We are mostly interested
 ![]({% img_url gdb-tips-and-tricks/uart_folder.png %})
 <br/>
 
-Before we build the example, let's make sure we have the right compiler flags for debugging. This is necessary to include debugging symbols that help GDB present useful debugging information to the user. 
+Before we build the example, let's make sure we have the right compiler flags for debugging. This is necessary to include debugging symbols that help GDB present useful debugging information to the user.
 
 To check the compiler flags, edit the `Makefile` located at `<nRF5_SDK_Folder>/examples/peripheral/uart/pca10056/blank/armgcc`.
 
@@ -261,13 +261,13 @@ Here are the steps to accomplish this:
 	- **Power** set to "ON"
 
 	![]({% img_url gdb-tips-and-tricks/nRF52840_dev_kit.png %})
-	
+
 - Erase the development kit by running the following command:
 
 	```terminal
 	$ nrfjprog -f NRF52 --eraseall
 	```
-	
+
 - The final step is to flash the development kit with the example's binary.
 
 	To do so, run the following command from the folder `<nRF5_SDK_Folder>/examples/peripheral/blinky/pca10056/blank/armgcc`.
@@ -275,7 +275,7 @@ Here are the steps to accomplish this:
 	```terminal
 	$ nrfjprog -f NRF52 --program _build/nrf52840_xxaa.hex --chiperase
 	```
-	
+
 That's it!
 
 Now the nRF52840 development kit should be flashed with the UART example and it should be running properly.
@@ -289,27 +289,27 @@ There are three parts to get this working:
 
 - Run the CoolTerm application
 - Make sure the serial port settings are correct (listed at [this link](https://infocenter.nordicsemi.com/topic/com.nordic.infocenter.sdk5.v15.3.0/uart_example.html)):
- 
-	
+
+
 	![]({% img_url gdb-tips-and-tricks/CoolTerm_Settings.png %})
-	
-	Now, hit **OK**. 
+
+	Now, hit **OK**.
 
 - Finally, connect to the serial port by clicking the "Connect" button:
-	
+
 	![]({% img_url gdb-tips-and-tricks/CoolTerm_Connect.png %})
-	
+
 	You may not see any output since the program probably started before you connected. To reset the development board, we can simply run the following command from the Terminal:
-	
+
 	```terminal
 	$ nrfjprog -f NRF52 --reset
 	```
-	
+
 	If all goes well, you should see the following printed in the Terminal window:
-	
-	
+
+
 	![]({% img_url gdb-tips-and-tricks/CoolTerm_Output.png %})
-	
+
 
 ## Debugging the Program
 Now that we have the application running properly, let's go ahead and set up the debugger.
@@ -318,65 +318,65 @@ Now that we have the application running properly, let's go ahead and set up the
 There are a few steps to get this working.
 
 - **JLinkGDBServer**
-	
+
 	As part of the SEGGER J-Link Software we installed, the program JLinkGDBServer is included. This is the GDB Server application that will interface directly with the development kit and the nRF52840 chipset. It will open up a port (we chose port 2331) over the network to allow connections from a GDB Client.
-	
+
 	To start the J-Link GDB Server, run the following command:
-	
+
 	```terminal
 	$ JLinkGDBServerCL -device nrf52840_xxaa -if swd -port 2331
 	```
-	
+
 	- "**-device**" specifies the device type ("nrf52840_xxaa" in our case).
 	- "**-if**" specifies the debug interface ("swd" refers to Serial Wire Debug which is an alternative to JTAG that is relatively recent and is used for ARM processors. Keep in mind that some chipsets may not support SWD and will require JTAG instead.)
 	- "**-port**" specifies the network port where the GDB Server will be accessible by the GDB Client.
-	
+
 	The output should look something like this:
-	
+
 	![]({% img_url gdb-tips-and-tricks/GDB_Server_Run.png %})
-	
-	
+
+
 - **Running GDB**
 
 	Now that the GDB Server is running, we have to connect to it from a GDB Client. In our case, the client is the `arm-none-eabi-gdb` program included as part of the GNU Arm Embedded Toolchain we downloaded earlier.
-	
+
 	To make things easier, run the following command from the output folder where the binary images for the compiled example are located (`<nRF5_SDK_Folder>/examples/peripheral/uart/pca10056/blank/armgcc/_build/`).
-	
+
 	```terminal
 	$ arm-none-eabi-gdb
 	```
-	
-	
+
+
 	![]({% img_url gdb-tips-and-tricks/arm_gdb_run.png %})
-	
+
 
 	Next, we want to tell GDB what output file is used for the program running on the development kit. We do so with the following command within the GDB console:
-	
+
 	```bash
 	(gdb) file nrf52840_xxaa.out
 	```
 
-	
+
 	![]({% img_url gdb-tips-and-tricks/arm_gdb_file.png %})
-	
-	
+
+
 - **Connecting GDB to the Remote Target**
-	
+
 	The last step is to connect to the GDB server:
-	
+
 	```bash
 	(gdb) target remote localhost:2331
 	```
-	
-	
+
+
 	![]({% img_url gdb-tips-and-tricks/arm_gdb_target.png %})
-	
-	
+
+
 	The GDB Server (which should be left running in another Terminal window) will show something like the following:
-	
-	
+
+
 	![]({% img_url gdb-tips-and-tricks/GDB_Server_connected.png %})
-	
+
 
 ### 2. GDB Commands
 Now that we've been able to connect the debugger to the nRF52 chipset on the development kit, it's time to start having some fun!
@@ -458,7 +458,7 @@ Let's take a look at how the Step command behaves after hitting the breakpoint a
 
 ![]({% img_url gdb-tips-and-tricks/gdb_step.png %})
 
- 
+
 Notice that GDB stepped into the function **app_uart_get()** after reaching line 172.
 
 #### List
@@ -476,15 +476,15 @@ The **Info** command has many uses, but as the name implies, it is used to displ
 Here are some examples for uses of **Info**.
 
 - **Info locals**: shows information about all local variables.
-	
+
 	![]({% img_url gdb-tips-and-tricks/gdb_info_locals.png %})
-	
+
 - **Info variables**: shows information about all types of variables (local and global).
-	
+
 	![]({% img_url gdb-tips-and-tricks/gdb_info_variables.png %})
-	
-- **Info files**: shows information about all files being debugged. 
-	
+
+- **Info files**: shows information about all files being debugged.
+
 	![]({% img_url gdb-tips-and-tricks/gdb_info_files.png %})
 
 #### Logging
@@ -507,7 +507,7 @@ Some ideas for future GDB-related posts include:
 
 What other GDB tips and tricks do you know? Are you facing any problems or struggles with using GDB?
 
-Let us know in the discussion area below! 
+Let us know in the discussion area below!
 
 ## Useful Resources
 Finally, I'll leave you with some useful GDB resources that I've referred to over the years:

--- a/_posts/2019-06-25-how-to-write-linker-scripts-for-firmware.md
+++ b/_posts/2019-06-25-how-to-write-linker-scripts-for-firmware.md
@@ -37,8 +37,7 @@ somewhere is the linker script.
 Once again, we will use our simple "minimal" program, available [on
 Github](https://github.com/memfault/zero-to-main/blob/master/minimal).
 
-_Like Interrupt? [Subscribe](http://eepurl.com/gpRedv) to get our latest
-posts straight to your mailbox_
+{% include newsletter.html %}
 
 ## Brief Primer on Linking
 
@@ -576,8 +575,7 @@ _EDIT: Post written!_ - [Writing a Bootloader from Scratch]({% post_url 2019-08-
 As with previous posts, code examples are available on Github in the [zero to main
 repository](https://github.com/memfault/zero-to-main)
 
-See anything you'd like to change? Submit a pull request or open an issue at
-[Github](https://github.com/memfault/interrupt)
 
-_Like Interrupt? [Subscribe](http://eepurl.com/gpRedv) to get our latest posts
-straight to your mailbox_
+{% include submit-pr.html %}
+
+{% include newsletter.html %}

--- a/_posts/2019-07-02-automate-debugging-with-gdb-python-api.md
+++ b/_posts/2019-07-02-automate-debugging-with-gdb-python-api.md
@@ -34,8 +34,7 @@ Manually inspecting hundreds of crashes is no fun ... but fortunately, GDB allow
 
 In this series of posts we will explore some of the GDB Python APIs and how they can be used.
 
-_Like Interrupt? [Subscribe](http://eepurl.com/gpRedv) to get our latest
-posts straight to your mailbox_
+{% include newsletter.html %}
 
 ## Getting started with GDB Python
 
@@ -388,8 +387,8 @@ We hope this post gave you a useful overview of how to add custom GDB commands a
 
 Do you already have some ideas about how the Python API could be applied to automate parts of your debugging flow ... perhaps a command to walk custom heaps or display the contents in a memory-mapped filesystem? Or maybe you are already have some great examples of how you have used GDB Python? Either way, let us know in the discussion area below!
 
-Next time, we'll talk about how to use third-party Python packages within GDB using virtual environments. 
+Next time, we'll talk about how to use third-party Python packages within GDB using virtual environments.
 
-_EDIT: Post written!_ - [Using Python PyPi Packages with GDB]({% post_url 2019-07-23-using-pypi-packages-with-GDB %}) 
+_EDIT: Post written!_ - [Using Python PyPi Packages with GDB]({% post_url 2019-07-23-using-pypi-packages-with-GDB %})
 
-_All the code used in this blog post is available on [Github](https://github.com/memfault/interrupt/tree/master/example/gdb-python-post/). See anything you'd like to change? Submit a pull request!_
+_All the code used in this blog post is available on [Github](https://github.com/memfault/interrupt/tree/master/example/gdb-python-post/)._ {% include submit-pr.html %}

--- a/_posts/2019-07-16-fix-bugs-and-secure-firmware-with-the-mpu.md
+++ b/_posts/2019-07-16-fix-bugs-and-secure-firmware-with-the-mpu.md
@@ -18,8 +18,7 @@ In this article, we will deep dive into the unit and walk through a few practica
 
 <!-- excerpt end -->
 
-_Like Interrupt? [Subscribe](http://eepurl.com/gpRedv) to get our latest
-posts straight to your mailbox_
+{% include newsletter.html %}
 
 {:.no_toc}
 
@@ -395,4 +394,4 @@ We hope this post gave you a useful overview of how the _ARMv6-M_ & _ARMv7-M_ MP
 
 Do you use the MPU on your products? Have you had a use case where you've leveraged some of the more interesting configuration options (i.e `SRD` region masking or more complex selection of `TEX`, `S`, `C`, `B` values for a _Cortex-M7_ with some caches)? Or do you have any questions about the material in the blog post or wish there were some other details we covered? Let us know in the discussion area below!
 
-See anything you'd like to change? Submit a pull request on [Github](https://github.com/memfault/interrupt)
+{% include submit-pr.html %}

--- a/_posts/2019-07-23-using-pypi-packages-with-GDB.md
+++ b/_posts/2019-07-23-using-pypi-packages-with-GDB.md
@@ -88,8 +88,7 @@ print(x)
 
 Let's go ahead and try it out!
 
-_Like Interrupt? [Subscribe](http://eepurl.com/gpRedv) to get our latest posts
-straight to your mailbox_
+{% include newsletter.html %}
 
 ## Setting up GDB's Python and PyPi
 
@@ -487,5 +486,5 @@ If you use `lldb`, here is an
 [`.lldbinit` Github Gist](https://gist.github.com/tyhoff/7a286945ef75947ad49a347dbc8708ca).
 
 _All the code used in this blog post is available on
-[Github](https://github.com/memfault/interrupt/tree/master/example/gdb-python-pypi-post/).
-See anything you'd like to change? Submit a pull request!_
+[Github](https://github.com/memfault/interrupt/tree/master/example/gdb-python-pypi-post/)._
+{% include submit-pr.html %}

--- a/_posts/2019-08-06-a-deep-dive-into-arm-cortex-m-debug-interfaces.md
+++ b/_posts/2019-08-06-a-deep-dive-into-arm-cortex-m-debug-interfaces.md
@@ -15,8 +15,7 @@ In this article we will walk up through the hardware and software stack that ena
 
 <!-- excerpt end -->
 
-_Like Interrupt? [Subscribe](http://eepurl.com/gpRedv) to get our latest
-posts straight to your mailbox_
+{% include newsletter.html %}
 
 ## The ARM Debugger Stack
 
@@ -340,7 +339,7 @@ Future topics we'd love to delve into related to debuggers include the Embedded 
 
 Are there other topics you'd like us to cover? Or are there topics in this article you'd love to see more details on? Just let us know in the discussion area below!
 
-See anything you'd like to change? Submit a pull request on [Github](https://github.com/memfault/interrupt)
+{% include submit-pr.html %}
 
 ## Useful Reference Links
 

--- a/_posts/2019-08-13-how-to-write-a-bootloader-from-scratch.md
+++ b/_posts/2019-08-13-how-to-write-a-bootloader-from-scratch.md
@@ -27,8 +27,7 @@ bootloader, how to implement one, and cover a few advanced techniques you may
 use to make your bootloader more useful.
 <!-- excerpt end -->
 
-_Like Interrupt? [Subscribe](http://eepurl.com/gpRedv) to get our latest
-posts straight to your mailbox_
+{% include newsletter.html %}
 
 {:.no_toc}
 
@@ -111,7 +110,7 @@ I decided to go with a 16kB region, leading to the following memory map:
 
 We can transcribe that memory into a linker script:
 
-``` 
+```
 /* memory_map.ld */
 MEMORY
 {
@@ -172,7 +171,7 @@ SECTIONS
         *(.rodata*)
         _etext = .;
     } > bootrom
-  ... 
+  ...
 }
 ```
 
@@ -203,10 +202,10 @@ bit of assembly code.
 ARM MCUs use the [`msr` instruction
 ](http://www.keil.com/support/man/docs/armasm/armasm_dom1361289882044.htm) to
 load immediate or register data into system registers, in this case the MSP
-register or “Main Stack Pointer”. 
+register or “Main Stack Pointer”.
 
 Jumping to an address is done with a branch, in our case with a [`bx`
-instruction](http://www.keil.com/support/man/docs/armasm/armasm_dom1361289866466.htm). 
+instruction](http://www.keil.com/support/man/docs/armasm/armasm_dom1361289866466.htm).
 
 We wrap those two into a `start_app` function which accepts our `pc` and `sp` as
 arguments, and get our minimal bootloader:
@@ -257,7 +256,7 @@ SECTIONS
         *(.rodata*)
         _etext = .;
     } > approm
-  ... 
+  ...
 }
 ```
 
@@ -298,7 +297,7 @@ our `Reset_Handler`:
 uint32_t *vector_table = (uint32_t *) &_stext;
 uint32_t *vtor = (uint32_t *)0xE000ED08;
 *vtor = ((uint32_t) vector_table & 0xFFFFFFF8);
-``` 
+```
 
 One quirk of the ARMv7-m architecture is the alignment requirement for the
 vector table, as specified in section B1.5.3 of the [reference
@@ -376,7 +375,7 @@ To do that, you must go through the following steps:
 3. Concatenate the two
 
 Creating a binary from an elf file is done with `objcopy` . To
-accommodate our use case, `objcopy` has some handy options: 
+accommodate our use case, `objcopy` has some handy options:
 
 ```
 $ arm-none-eabi-objcopy --help | grep -C 2 pad
@@ -558,7 +557,7 @@ SECTIONS {
 We then update our bootloader to copy our code from one to the other before
 starting the app:
 
-```c 
+```c
   /* booloader.c */
 
   /* copy app code to eram */
@@ -626,11 +625,4 @@ Next time in the series, we'll talk about bootstrapping the C library!
 
 _EDIT: Post written!_ - [Bootstrapping libc with Newlib]({% post_url 2019-11-12-boostrapping-libc-with-newlib %})
 
-_Like Interrupt? [Subscribe](http://eepurl.com/gpRedv) to get our latest
-posts straight to your mailbox_
-
-
-
-
-
-
+{% include newsletter.html %}

--- a/_posts/2019-08-20-code-size-optimization-gcc-flags.md
+++ b/_posts/2019-08-20-code-size-optimization-gcc-flags.md
@@ -5,7 +5,7 @@ author: francois
 tags: [fw-code-size]
 ---
 
-## Introduction 
+## Introduction
 
 This is the second post in our [Firmware Code Size Optimization]({% tag_url fw-code-size %}) series. [Last time]({% post_url
 2019-06-06-best-firmware-size-tools %}), we talked about measuring code size as a
@@ -22,8 +22,7 @@ You would think that a single flag could be used for “make this as small as
 possible”, but unfortunately it isn’t so. Instead, code size optimization
 involves complicated trade-offs that must be considered on a case by case basis.
 
-_Like Interrupt? [Subscribe](http://eepurl.com/gpRedv) to get our latest posts
-straight to your mailbox_
+{% include newsletter.html %}
 
 {:.no_toc}
 
@@ -170,7 +169,7 @@ the rest of the file is compiled with the regular options.
 
 Now that we’ve set the appropriate optimization level, we turn our attention to
 dead code elimination. Most programs contain dead code: it may come from
-libraries you use partially, or test functions you left in the final program. 
+libraries you use partially, or test functions you left in the final program.
 
 Since the compiler operates on one file at a time, it does not have enough
 context to decide whether a function is dead code or not. Consider a library
@@ -385,8 +384,7 @@ few compiler flag changes cut it down by more than half!
 Future posts in this series will consider coding style, and even some desperate
 hacks one can use to slim down code size further.
 
-_Like Interrupt? [Subscribe](http://eepurl.com/gpRedv) to get our latest posts
-straight to your mailbox_
+{% include newsletter.html %}
 
 ## Reference & Links
 

--- a/_posts/2019-08-27-building-a-cli-for-firmware-projects.md
+++ b/_posts/2019-08-27-building-a-cli-for-firmware-projects.md
@@ -62,8 +62,7 @@ $ invoke flash
 A web service's REST API needs to be **stable, easy to use, and self
 documenting**. Your project's CLI should meet the same requirements.
 
-_Like Interrupt? [Subscribe](http://eepurl.com/gpRedv) to get our latest posts
-straight to your mailbox_
+{% include newsletter.html %}
 
 ### When to Build a Project CLI
 
@@ -529,8 +528,7 @@ tasks and features:
   installed using `pre` tasks
 - We can run `inv --list` and `inv <command> --help` for help menus.
 
-_Like Interrupt? [Subscribe](http://eepurl.com/gpRedv) to get our latest posts
-straight to your mailbox_
+{% include newsletter.html %}
 
 ## Final Thoughts
 
@@ -543,8 +541,8 @@ our service, performing database migrations...everything. The self-documenting
 nature of the commands is indispensable.
 
 _All the code used in this blog post is available on
-[Github](https://github.com/memfault/interrupt/tree/master/example/invoke-basic/).
-See anything you'd like to change? Submit a pull request!_
+[Github](https://github.com/memfault/interrupt/tree/master/example/invoke-basic/)._
+{% include submit-pr.html %}
 
 {:.no_toc}
 

--- a/_posts/2019-09-04-arm-cortex-m-exceptions-and-nvic.md
+++ b/_posts/2019-09-04-arm-cortex-m-exceptions-and-nvic.md
@@ -739,7 +739,7 @@ topic but I've always found it hard to find a single place that aggregates the u
 Are there any other topics related to interrupts you'd like us to delve into? (No pun intended :D) Do you leverage any of
 ARMs fancy exception configuration features in your products? Let us know in the discussion area below!
 
-See anything you'd like to change? Submit a pull request or open an issue at [Github](https://github.com/memfault/interrupt)
+{% include submit-pr.html %}
 
 {:.no_toc}
 

--- a/_posts/2019-09-17-continuous-integration-for-firmware.md
+++ b/_posts/2019-09-17-continuous-integration-for-firmware.md
@@ -75,14 +75,13 @@ codebase working at scale. As complexity and velocity grow:
 * Finding when and where an issue was introduced gets more difficult
 * Side effects are less well understood, making it more likely that a change in
    one part of the codebase will break a feature in another.
-* Testing every feature and hardware configuration takes more and more time. 
+* Testing every feature and hardware configuration takes more and more time.
 
 Additionally, CI infrastructure serves as a reference environment which can be
 used to reproduce builds and generate shipping images. No more "it works on
 my machine". If it fails in CI, it must be considered broken.
 
-_Like Interrupt? [Subscribe](http://eepurl.com/gpRedv) to get our latest posts
-straight to your mailbox_
+{% include newsletter.html %}
 
 ## Continuous Integration Systems
 
@@ -140,7 +139,7 @@ $ cd ChibiOS/ext
 $ 7za x fatfs-0.13c_patched.7z
 # Build the example
 $ cd ../demos/STM32/RT-STM32F103-STM3210E_EVAL-FATFS-USB
-$ make -j 
+$ make -j
 ```
 
 Which should give us:
@@ -193,7 +192,7 @@ collection of steps executed sequentially in a specific environment. A
 based on more complex logic.
 
 You can read more about Steps, Jobs, and Workflows in CircleCI’s
-documentation[^3] 
+documentation[^3]
 
 For our hello world example, we will have a single job, with the following steps:
 1. Check out the code repository
@@ -356,7 +355,7 @@ bones,  so to avoid having to install many common packages, we instead use the
 Next, we’ll want to install some firmware specific tools such as our compiler.
 This is easily done with a **Step**.
 
-```yaml 
+```yaml
 - run:
     name: Install apt dependencies
     command: sudo apt install p7zip-full gcc-arm-none-eabi binutils-arm-none-eabi
@@ -437,7 +436,7 @@ job page:
 
 ![]({% img_url circle-ci/real_build_ended.png %})
 
-Where we can now find our artifacts! 
+Where we can now find our artifacts!
 
 ![]({% img_url circle-ci/chibios_artifact.png %})
 
@@ -479,7 +478,7 @@ ChibiOS comes with many such tests. For example, the RT kernel tests can be foun
 
 ```shell
 ~/ChibiOS $ cd test/rt/testbuild
-~/ChibiOS/test/rt/testbuild $ make 
+~/ChibiOS/test/rt/testbuild $ make
 [...]
 Compiling oslib_test_sequence_006.c
 Compiling oslib_test_sequence_007.c

--- a/_posts/2019-09-24-ble-throughput-primer.md
+++ b/_posts/2019-09-24-ble-throughput-primer.md
@@ -17,8 +17,7 @@ In this article, we dive into the factors which influence BLE throughput. We wil
 
 I recommend starting with our [Primer on Bluetooth Low Energy]({% post_url 2019-07-30-bluetooth-low-energy-a-primer %}) if this is your first time working with BLE.
 
-_Like Interrupt? [Subscribe](http://eepurl.com/gpRedv) to get our latest
-posts straight to your mailbox_
+{% include newsletter.html %}
 
 {:.no_toc}
 
@@ -351,7 +350,7 @@ I hope this post gave you a useful overview of the factors which control BLE thr
 
 Are there any other topics related to BLE throughput you'd like us to explore further? Are there any cool optimizations you have made in the BLE stack you use today? Let us know in the discussion area below!
 
-See anything you'd like to change? Submit a pull request or open an issue at [Github](https://github.com/memfault/interrupt)
+{% include submit-pr.html %}
 
 {:.no_toc}
 

--- a/_posts/2019-10-08-unit-testing-basics.md
+++ b/_posts/2019-10-08-unit-testing-basics.md
@@ -111,8 +111,7 @@ set up expectations up front.
    leave software stability to unit tests. If time allows, then build these
    types of tests.
 
-_Like Interrupt? [Subscribe](http://eepurl.com/gpRedv) to get our latest posts
-straight to your mailbox_
+{% include newsletter.html %}
 
 ## Framework-less Unit Tests
 
@@ -1249,8 +1248,7 @@ writing a unit test for your next new embedded software module.
 You can find the examples shown in this post
 [here](https://github.com/memfault/interrupt/tree/master/example/unit-testing).
 
-_Like Interrupt? [Subscribe](http://eepurl.com/gpRedv) to get our latest posts
-straight to your mailbox_
+{% include newsletter.html %}
 
 {:.no_toc}
 
@@ -1263,5 +1261,4 @@ straight to your mailbox_
 [^5]: [Memfault Public SDK](https://github.com/memfault/memfault-firmware-sdk)
 [^6]: [AddressSanitizer](https://github.com/google/sanitizers/wiki/AddressSanitizer)
 
-See anything you'd like to change? Submit a pull request or open an issue at
-[Github](https://github.com/memfault/interrupt)
+{% include submit-pr.html %}

--- a/_posts/2019-10-22-best-and-worst-gcc-clang-compiler-flags.md
+++ b/_posts/2019-10-22-best-and-worst-gcc-clang-compiler-flags.md
@@ -19,8 +19,7 @@ each flag has by walking through practical C code examples.
 
 <!-- excerpt end -->
 
-_Like Interrupt? [Subscribe](http://eepurl.com/gpRedv) to get our latest posts
-straight to your mailbox_
+{% include newsletter.html %}
 
 {:.no_toc}
 
@@ -881,8 +880,7 @@ you some ideas of items to look into.
 
 Are there flags you wish I had also mentioned in this article? Let me know in the discussion area below!
 
-See anything you'd like to change? Submit a pull request or open an issue at
-[Github](https://github.com/memfault/interrupt)
+{% include submit-pr.html %}
 
 {:.no_toc}
 

--- a/_posts/2019-10-30-cortex-m-rtos-context-switching.md
+++ b/_posts/2019-10-30-cortex-m-rtos-context-switching.md
@@ -23,8 +23,7 @@ porting an RTOS to a platform. We will also walk through a practical example of 
 
 <!-- excerpt end -->
 
-_Like Interrupt? [Subscribe](http://eepurl.com/gpRedv) to get our latest posts
-straight to your mailbox_
+{% include newsletter.html %}
 
 {:.no_toc}
 
@@ -971,8 +970,7 @@ works.
 We'd love to hear interesting RTOS bugs you have tracked down or other topics you would like to see
 covered on the topic. Let me know in the discussion area below!
 
-See anything you'd like to change? Submit a pull request or open an issue at
-[Github](https://github.com/memfault/interrupt)
+{% include submit-pr.html %}
 
 ## Reference Links
 

--- a/_posts/2019-11-05-asserts-in-embedded-systems.md
+++ b/_posts/2019-11-05-asserts-in-embedded-systems.md
@@ -61,8 +61,7 @@ device, all while keeping the code size usage to a minimum.
 - The examples below are implemented for the ARM Cortex-M series of MCUs. Many
   of the concepts can be generalized to other architectures.
 
-_Like Interrupt? [Subscribe](http://eepurl.com/gpRedv) to get our latest posts
-straight to your mailbox_
+{% include newsletter.html %}
 
 ## Making the Most of Asserts
 
@@ -650,8 +649,7 @@ only one piece of this puzzle, and they need to be paired with solid debugging
 infrastructure such as logging, postmortem backtrace and coredump collection,
 and automated analysis of these diagnostics.
 
-See anything you'd like to change? Submit a pull request or open an issue at
-[Github](https://github.com/memfault/interrupt)
+{% include submit-pr.html %}
 
 ## Reference Links
 

--- a/_posts/2019-11-12-boostrapping-libc-with-newlib.md
+++ b/_posts/2019-11-12-boostrapping-libc-with-newlib.md
@@ -102,14 +102,14 @@ int main() {
     for (int i = 0; i < 100000; ++i) {}
   }
 }
-``` 
+```
 
 ## Implementing Newlib
 ### Why Newlib?
 
 There are several implementations of the C Standard Library, starting with the
 venerable `glibc` found on most GNU/Linux systems. Alternative implementations
-include Musl libc[^2], Bionic libc[^3], ucLibc[^4], and dietlibc[^5]. 
+include Musl libc[^2], Bionic libc[^3], ucLibc[^4], and dietlibc[^5].
 
 Newlib is an implementation of the C Standard Library targeted at bare-metal
 embedded systems that is maintained by RedHat. It has become the de-facto standard
@@ -243,7 +243,7 @@ The complete list of them is provided below:
 ```
 _exit, close, environ, execve, fork, fstat, getpid, isatty, kill,
 link, lseek, open, read, sbrk, stat, times, unlink, wait, write
-``` 
+```
 
 You’ll notice that several of the syscalls relate to filesystem operation or
 process control. These do not make much sense in a firmware context, so we’ll
@@ -266,7 +266,7 @@ int fstat(int file, struct stat *st) {
 #### lseek
 
 `lseek` repositions the file offset of the open file associated with the file
-descriptor `fd` to the argument `offset` according to the directive `whence`. 
+descriptor `fd` to the argument `offset` according to the directive `whence`.
 
 Here we can simply return 0, which implies the file is empty.
 
@@ -345,7 +345,7 @@ int main() {
 #### read
 
 `read`  attempts to read up to `count` bytes from file descriptor `fd` into the
-buffer at `buf`. 
+buffer at `buf`.
 
 Similarly to `write`, we want `read` to read bytes from serial:
 
@@ -369,7 +369,7 @@ it increases the size of the heap.
 
 What does `printf` have to do with the heap, you will justly ask? It turns out
 that newlib’s `printf` implementations allocates data on the heap and depends on
-a working `malloc` implementation. 
+a working `malloc` implementation.
 
 The source for `printf` is hard to follow, but you will find that indeed [it
 calls
@@ -526,7 +526,7 @@ Although we could perfectly well stop here, we can improve a bit over the above.
 
 In our example, `printf` depends implicitly on `serial_init` being called. This
 isn’t the end of the world, but it goes against the spirit of a standard library
-function which should be usable anywhere in our program. 
+function which should be usable anywhere in our program.
 
 Instead, let’s see what we can do so that this works:
 
@@ -594,7 +594,7 @@ code](https://github.com/bminor/newlib/blob/master/newlib/libc/misc/init.c).
 All we need to do is call `__libc_init_array` prior to `main` in our
 `Reset_Handler`, and we are good to go.
 
-```c 
+```c
 void Reset_Handler(void)
 {
   /* ... */
@@ -658,7 +658,7 @@ because it is too large or because it depends on dynamic memory management.
 Using Marco Paland’s excellent alternative[^7] is as simple as a Makefile change.
 
 We first clone it in our firmware’s folder under `lib/printf`, and update our
-Makefile to reflect the change: 
+Makefile to reflect the change:
 
 ```makefile
 PROJECT := with-libc
@@ -709,7 +709,7 @@ SRCS = \
 	$(PROJECT).c
 
 include ../common-standalone.mk
-``` 
+```
 
 > Note that the `__libc_init_array` functionality is not found in every standard
 > C library. You will either need to avoid using it, or bring in Newlib’s
@@ -729,8 +729,7 @@ Next time in the series, we'll talk about Rust!
 
 _EDIT: Post written!_ - [From Zero to main(): Bare metal Rust]({% post_url 2019-12-17-zero-to-main-rust-1 %})
 
-_Like Interrupt? [Subscribe](http://eepurl.com/gpRedv) to get our latest
-posts straight to your mailbox_
+{% include newsletter.html %}
 
 ## Reference Links
 

--- a/_posts/2019-11-20-cortex-m-fault-debug.md
+++ b/_posts/2019-11-20-cortex-m-fault-debug.md
@@ -20,8 +20,7 @@ some faults without rebooting the MCU. We include practical examples, with a ste
 
 <!-- excerpt end -->
 
-_Like Interrupt? [Subscribe](http://eepurl.com/gpRedv) to get our latest
-posts straight to your mailbox_
+{% include newsletter.html %}
 
 {:.no_toc}
 
@@ -1081,7 +1080,7 @@ I hope this post gave you a useful overview of how to debug a HardFault on a Cor
 Are there tricks you like to use that I didn't mention or other topics about faults you'd like to learn more about?
 Let us know in the discussion area below!
 
-See anything you'd like to change? Submit a pull request or open an issue at [Github](https://github.com/memfault/interrupt)
+{% include submit-pr.html %}
 
 {:.no_toc}
 

--- a/_posts/2019-12-11-reproducible-firmware-builds.md
+++ b/_posts/2019-12-11-reproducible-firmware-builds.md
@@ -597,7 +597,7 @@ I hope this post gave you a useful overview of the benefits of reproducible buil
 
 Are the builds for your project reproducible today? Are there other matters on the topic that you would have liked to see us cover? Let us know in the discussion area below!
 
-See anything you'd like to change? Submit a pull request or open an issue at [Github](https://github.com/memfault/interrupt)
+{% include submit-pr.html %}
 
 {:.no_toc}
 

--- a/_posts/2020-01-07-conda-developer-environments.md
+++ b/_posts/2020-01-07-conda-developer-environments.md
@@ -28,8 +28,7 @@ environment.
 
 <!-- excerpt end -->
 
-_Like Interrupt? [Subscribe](http://eepurl.com/gpRedv) to get our latest posts
-straight to your mailbox_
+{% include newsletter.html %}
 
 {:.no_toc}
 

--- a/_posts/2020-01-22-i2c-in-a-nutshell.md
+++ b/_posts/2020-01-22-i2c-in-a-nutshell.md
@@ -21,8 +21,7 @@ firmware engineers encounter it on most projects. In this post, we explain how I
 works, explore common bugs and investigate how to debug these issues.
 <!-- excerpt end -->
 
-_Like Interrupt? [Subscribe](http://eepurl.com/gpRedv) to get our latest posts
-straight to your mailbox_
+{% include newsletter.html %}
 
 {:.no_toc}
 
@@ -44,7 +43,7 @@ signalling).
    interfaces as well as fan control, temperature sensing and other low-speed
 contol loops.
 4. Historically, it has been less onerous for manufacturers to include than
-   competing protocols like Maxim's 1-wire protocol[^4]. 
+   competing protocols like Maxim's 1-wire protocol[^4].
 
 Many of the sensors and actuators in devices all around us use I2C:
 temperature sensors, accelerometers, gyroscopes, fans, video bridging chips,
@@ -76,7 +75,7 @@ transmitted bit.
 For example, this is `0xC9` over I2C:
 
 <script type="WaveDrom">
-{ signal : 
+{ signal :
   [
     { name: "SDA",  wave: "101.0.10.101." },
     { name: "SCL",  wave: "1.n........h."},
@@ -103,7 +102,7 @@ In the diagram below, we indicate the START and STOP condition with "S" and "P"
 respectively.
 
 <script type="WaveDrom">
-{ signal : 
+{ signal :
   [
     { name: "SDA",  wave: "101.0.10.101." },
     { name: "SCL",  wave: "1.n........h."},
@@ -125,7 +124,7 @@ To communicate with a slave device, an I2C master simply needs to write its
 below captures an I2C transaction to a slave with address 0x66:
 
 <script type="WaveDrom">
-{ signal : 
+{ signal :
   [
     { name: "SDA",  wave: "101.0.1.010|.101." },
     { name: "SCL",  wave: "1.n........|...h."},
@@ -154,7 +153,7 @@ a `0` means it is a write.
 The example below shows a read sent to the slave device at address `0x66`.
 
 <script type="WaveDrom">
-{ signal : 
+{ signal :
   [
     { name: "SDA",  wave: "101.0.1.010|.101." },
     { name: "SCL",  wave: "1.n........|...h."},
@@ -167,7 +166,7 @@ The example below shows a read sent to the slave device at address `0x66`.
 
 A common pattern is to send a write followed by a read. For example, many
 devices expose several registers that can be read/written by first sending the
-register address to the device in with a write command. 
+register address to the device in with a write command.
 
 To achieve this, the I2C master must first send a write command with the
 register address, followed by a second START condition and a full read command
@@ -177,7 +176,7 @@ For example, this is what a write-then-read transaction to read register `0x11`
 from the slave device at address `0x66` would look like:
 
 <script type="WaveDrom">
-{ signal : 
+{ signal :
   [
     { name: "", wave: "x==..==...==..==.=x", data: ["S", "Address: 0x66", "W",
 "Reg Address: 0x11", "S", "Address: 0x66", "R", "Data", "P"]}
@@ -213,7 +212,7 @@ writes `0x9C` to the slave at address `0x66`.
 
 <!-- Can't get the narrow skin to work, so using an image
 <script type="WaveDrom">
-{ signal : 
+{ signal :
   [
     { name: "SDA",  wave: "101.0.1.01010.1..0.101."},
     { name: "SCL",  wave: "1.n..................h."},
@@ -308,7 +307,7 @@ addresses.
 Often times, you will see the following on your logic analyzer:
 
 <script type="WaveDrom">
-{ signal : 
+{ signal :
   [
     { name: "SDA",  wave: "101.0.1.010.1."},
     { name: "SCL",  wave: "1.n.........h."},
@@ -346,7 +345,7 @@ in reset. Grab your voltmeter and start checking pins:
   regulator or toggle a MOSFET.
 * Is the chip power the correct voltage?
 * Does your slave device have a reset pin? Check that pin and make sure reset is
-  not asserted. 
+  not asserted.
 * Does it have an I2C-enable pin? Is that in the correct state?
 
 If all the voltages are correct, test another board or replace the IC. Perhaps
@@ -406,11 +405,9 @@ Did I miss any obscure part of the standard, or forget to mention a debugging
 technique you find particularly useful? Let us know in the discussion area
 below!
 
-See anything you'd like to change? Submit a pull request or open an issue at
-[Github](https://github.com/memfault/interrupt)
+{% include submit-pr.html %}
 
-_Like Interrupt? [Subscribe](http://eepurl.com/gpRedv) to get our latest posts
-straight to your mailbox_
+{% include newsletter.html %}
 
 {:.no_toc}
 ## Reference

--- a/_posts/2020-02-04-rust-for-digital-signal-processing.md
+++ b/_posts/2020-02-04-rust-for-digital-signal-processing.md
@@ -32,8 +32,7 @@ firmware today, and compare the process and performance to the equivalent code
 
 <!-- excerpt end -->
 
-_Like Interrupt? [Subscribe](http://eepurl.com/gpRedv) to get our latest posts
-straight to your mailbox_
+{% include newsletter.html %}
 
 {:.no_toc}
 
@@ -333,7 +332,7 @@ Like most compilers, `rustc` has multiple optimization levels[^3].
 
 #### Speed
 
-Here, the C project has been compiled using GCC's `-03` optimization level which 
+Here, the C project has been compiled using GCC's `-03` optimization level which
 turns on all optimizations for performance, no matter the code size or compilation time[^4].
 
 As for Rust, we have been compiling in debug mode, which disables all optimizations. One simple
@@ -368,7 +367,7 @@ Function written using C: **3 930** instructions counted
 The Rust function is about **1.8 times faster** than the CMSIS-DSP
 implementation.
 
-#### Code size 
+#### Code size
 
 Firmware is often constrained by code size just as much as it is by performance.
 We must make sure that Rust performance does not come at an unreasonable code
@@ -497,8 +496,7 @@ order to enjoy the productivity gains brought with Rust is an exciting prospect.
 Have you built digital signal processing pipelines in Rust? I'd love to hear
 your experience in the comments!
 
-_Like Interrupt? [Subscribe](http://eepurl.com/gpRedv) to get our latest posts
-straight to your mailbox_
+{% include newsletter.html %}
 
 {:.no_toc}
 

--- a/_posts/2020-02-11-improving-compilation-times-c-cpp-projects.md
+++ b/_posts/2020-02-11-improving-compilation-times-c-cpp-projects.md
@@ -27,8 +27,7 @@ couple extra tips for those using the GNU GCC compiler.
 
 Hold on tight, as there is a lot to talk about.
 
-_Like Interrupt? [Subscribe](http://eepurl.com/gpRedv) to get our latest posts
-straight to your mailbox_
+{% include newsletter.html %}
 
 {:.no_toc}
 
@@ -626,8 +625,8 @@ Do you have any further ideas or ways that you have employed to speed up your
 firmware builds? I'd love to hear them!
 
 _All the code used in this blog post is available on
-[Github](https://github.com/memfault/interrupt/tree/master/example/faster-compilation/).
-See anything you'd like to change? Submit a pull request!_
+[Github](https://github.com/memfault/interrupt/tree/master/example/faster-compilation/)._
+{% include submit-pr.html %}
 
 {:.no_toc}
 

--- a/_posts/2020-02-18-firmware-watchdog-best-practices.md
+++ b/_posts/2020-02-18-firmware-watchdog-best-practices.md
@@ -20,8 +20,7 @@ In this article we will discuss the last line of defense in embedded systems -- 
 
 <!-- excerpt end -->
 
-_Like Interrupt? [Subscribe](http://eepurl.com/gpRedv) to get our latest
-posts straight to your mailbox_
+{% include newsletter.html %}
 
 {:.no_toc}
 
@@ -868,7 +867,7 @@ I hope this post gave you a useful overview of how to think about utilizing watc
 Do you have suggestions about how to use watchdogs that I didn't mention in this post or have any other questions on the topic?
 Let us know in the discussion area below!
 
-See anything you'd like to change? Submit a pull request or open an issue at [Github](https://github.com/memfault/interrupt)
+{% include submit-pr.html %}
 
 {:.no_toc}
 

--- a/_posts/2020-03-18-code-size-deltas.md
+++ b/_posts/2020-03-18-code-size-deltas.md
@@ -44,8 +44,7 @@ calculate code size deltas on every pull requests to keep it to a minimum.
 > this example
 > [code size dashboard for the Zephyr Project](https://zephyr-codesizes.herokuapp.com/public/dashboards/rsertKgwMwqHWzE24G4QUvbZhEe72x4hhsqMSqts?org_slug=default).
 
-_Like Interrupt? [Subscribe](http://eepurl.com/gpRedv) to get our latest posts
-straight to your mailbox_
+{% include newsletter.html %}
 
 {:.no_toc}
 
@@ -597,8 +596,8 @@ are a list of the resources I would start with:
 - [Puncover](https://github.com/HBehrens/puncover)
 
 _All the code used in this blog post is available on
-[Github](https://github.com/memfault/interrupt/tree/master/example/faster-compilation/).
-See anything you'd like to change? Submit a pull request!_
+[Github](https://github.com/memfault/interrupt/tree/master/example/faster-compilation/)._
+{% include submit-pr.html %}
 
 {:.no_toc}
 

--- a/_posts/2020-03-23-intro-to-renode.md
+++ b/_posts/2020-03-23-intro-to-renode.md
@@ -23,8 +23,7 @@ through integrated tests, and shorten the iteration cycle of development.
 
 <!-- excerpt end -->
 
-_Like Interrupt? [Subscribe](http://eepurl.com/gpRedv) to get our latest posts
-straight to your mailbox_
+{% include newsletter.html %}
 
 {:.no_toc}
 
@@ -634,7 +633,7 @@ custom Platform Description files and some Python peripheral implementations.
 
 All the code used in this blog post is aavailable on
 [Github](https://github.com/memfault/interrupt/tree/master/example/renode).
-See anything you'd like to change? Submit a pull request!
+{% include submit-pr.html %}
 
 {:.no_toc}
 

--- a/_posts/2020-04-08-gnu-binutils.md
+++ b/_posts/2020-04-08-gnu-binutils.md
@@ -1012,7 +1012,7 @@ I hope you learned something new about how to analyze binaries reading this arti
 
 Are there are tools or commands you find useful that we did not mention? Let us know in the discussion area below!
 
-See anything you'd like to change? Submit a pull request or open an issue at [Github](https://github.com/memfault/interrupt)
+{% include submit-pr.html %}
 
 {:.no_toc}
 

--- a/_posts/2020-04-14-gdbundle-plugin-manager.md
+++ b/_posts/2020-04-14-gdbundle-plugin-manager.md
@@ -63,8 +63,7 @@ for you.
 > [gdbundle](https://github.com/memfault/gdbundle) works perfectly with LLDB as
 > well.
 
-_Like Interrupt? [Subscribe](http://eepurl.com/gpRedv) to get our latest posts
-straight to your mailbox_
+{% include newsletter.html %}
 
 {:.no_toc}
 
@@ -493,8 +492,8 @@ nothing without the community and willing developers to hack something together.
 looking forward to any feature requests or issues that you can think of!
 
 _All the code used in this blog post is available on
-[Github](https://github.com/memfault/interrupt/tree/master/example/gdbundle-plugin-manager/).
-See anything you'd like to change? Submit a pull request!_
+[Github](https://github.com/memfault/interrupt/tree/master/example/gdbundle-plugin-manager/)._
+{% include submit-pr.html %}
 
 {:.no_toc}
 

--- a/_posts/2020-04-21-git-bisect.md
+++ b/_posts/2020-04-21-git-bisect.md
@@ -50,8 +50,7 @@ search through git bisect’s automation options.
 
 <!-- excerpt end -->
 
-_Like Interrupt? [Subscribe](http://eepurl.com/gpRedv) to get our latest posts
-straight to your mailbox_
+{% include newsletter.html %}
 
 {:.no_toc}
 

--- a/_posts/2020-05-12-unit-test-mocking.md
+++ b/_posts/2020-05-12-unit-test-mocking.md
@@ -37,8 +37,7 @@ everything you would need to know to get started writing unit tests for your
 embedded software project in C or C++ using CppUTest. We are going to jump
 quickly into the content so it's best to have read that post first.
 
-_Like Interrupt? [Subscribe](http://eepurl.com/gpRedv) to get our latest posts
-straight to your mailbox_
+{% include newsletter.html %}
 
 {:.no_toc}
 
@@ -1032,8 +1031,7 @@ them in the comments!
 You can find the examples shown in this post
 [here](https://github.com/memfault/interrupt/tree/master/example/unit-testing).
 
-See anything you'd like to change? Submit a pull request or open an issue at
-[Github](https://github.com/memfault/interrupt)
+{% include submit-pr.html %}
 
 {:.no_toc}
 

--- a/_posts/2020-05-20-arm-cortexm-with-llvm-clang.md
+++ b/_posts/2020-05-20-arm-cortexm-with-llvm-clang.md
@@ -976,7 +976,7 @@ LLVM/Clang and some of the neat things you can do once you have that working.
 I'd love to hear if you already using LLVM/Clang in your embedded project today and if so, whether
 it is for static analysis or for generating actual binaries. Either way, let us know in the discussion area below!
 
-See anything you'd like to change? Submit a pull request or open an issue at [Github](https://github.com/memfault/interrupt)
+{% include submit-pr.html %}
 
 {:.no_toc}
 

--- a/_posts/2020-06-02-profiling-firmware-on-cortex-m.md
+++ b/_posts/2020-06-02-profiling-firmware-on-cortex-m.md
@@ -27,8 +27,7 @@ method, and eventually discover ITM, DWT cycle counters, and more!
 <!-- excerpt end -->
 
 
-_Like Interrupt? [Subscribe](http://eepurl.com/gpRedv) to get our latest posts
-straight to your mailbox_
+{% include newsletter.html %}
 
 {:.no_toc}
 
@@ -52,7 +51,7 @@ support for our Discovery board, we simply need to connect our board to our
 laptop over USB via the "USB-STLINK" port, and run the following command on
 a recent version of the tool:
 
-```
+```bash
 $ openocd -f board/stm32f429disc1.cfg
 ```
 
@@ -677,7 +676,7 @@ with an open source tool such as openOCD and a single pin!
 Are there profiling tools or methods you've used to great effect? Let us know in
 the comments below!
 
-See anything you'd like to change? Submit a pull request or open an issue at [Github](https://github.com/memfault/interrupt)
+{% include submit-pr.html %}
 
 {:.no_toc}
 

--- a/_posts/2020-06-09-firmware-shell.md
+++ b/_posts/2020-06-09-firmware-shell.md
@@ -26,8 +26,7 @@ applicable to most embedded systems.
 
 <!-- excerpt end -->
 
-_Like Interrupt? [Subscribe](http://eepurl.com/gpRedv) to get our latest posts
-straight to your mailbox_
+{% include newsletter.html %}
 
 {:.no_toc}
 
@@ -982,8 +981,7 @@ features and code space usage in your shell.
 You can find the examples shown in this post
 [here](https://github.com/memfault/interrupt/tree/master/example/firmware-shell).
 
-See anything you'd like to change? Submit a pull request or open an issue at
-[Github](https://github.com/memfault/interrupt)
+{% include submit-pr.html %}
 
 {:.no_toc}
 

--- a/_posts/2020-06-17-cortex-m-breakpoints.md
+++ b/_posts/2020-06-17-cortex-m-breakpoints.md
@@ -21,8 +21,7 @@ In this article, we will discuss the basic types of breakpoints (hardware and so
 > Note: While the focus of the article will be about breakpoints and how they work for firmware based on ARM Cortex-M MCUs, the
 > general ideas presented apply to any compiled language and debugger.
 
-_Like Interrupt? [Subscribe](http://eepurl.com/gpRedv) to get our latest
-posts straight to your mailbox_
+{% include newsletter.html %}
 
 {:.no_toc}
 
@@ -667,7 +666,7 @@ I hope this post taught you something new about breakpoints and that the next ti
 
 I'd be curious to hear if you are making use of the ARM Cortex-M **FPB** in interesting ways for your product or if there are other topics you would have liked to have seen covered with respect to breakpoints. Either way, let us know in the discussion area below!
 
-See anything you'd like to change? Submit a pull request or open an issue at [Github](https://github.com/memfault/interrupt)
+{% include submit-pr.html %}
 
 {:.no_toc}
 

--- a/_posts/2020-06-23-device-firmware-update-cookbook.md
+++ b/_posts/2020-06-23-device-firmware-update-cookbook.md
@@ -26,8 +26,7 @@ I learned some of these lessons in this post the hard way, and I hope I can spar
 you and your colleagues a few sleepless nights spent debugging firmware update
 problems in the wild!
 
-_Like Interrupt? [Subscribe](http://eepurl.com/gpRedv) to get our latest posts
-straight to your mailbox_
+{% include newsletter.html %}
 
 ## Table of Contents
 
@@ -896,13 +895,10 @@ firmware update that we did not cover? Let us know! And if you see anything
 you'd like to change, don't hesitate to submit a pull request or open an issue
 on [Github](https://github.com/memfault/interrupt)
 
-_Like Interrupt? [Subscribe](http://eepurl.com/gpRedv) to get our latest posts
-straight to your mailbox_
+{% include newsletter.html %}
 
 {:.no_toc}
 ## References
 
 [^chris-dfu-debug]: This is not the end to this story. My cofounder Chris eventually found a set of inputs to provide to the device which would set the stack just so and allow us to update out of that state. Phew!
 [^pebble-3]: At the time, we wrote a blog post about it. You can still read it on the [Internet Archive](https://web.archive.org/web/20160308073714/https://blog.getpebble.com/2015/12/09/3ontintin/)
-
-

--- a/_posts/2020-07-07-test-automation-renode.md
+++ b/_posts/2020-07-07-test-automation-renode.md
@@ -30,8 +30,7 @@ these tests within GitHub's continuous integration system.
 
 <!-- excerpt end -->
 
-_Like Interrupt? [Subscribe](http://eepurl.com/gpRedv) to get our latest posts
-straight to your mailbox_
+{% include newsletter.html %}
 
 {:.no_toc}
 
@@ -998,8 +997,7 @@ using Renode to test all aspects of the Memfault Firmware SDK[^memfault_sdk].
 You can find the examples shown in this post
 [here](https://github.com/memfault/interrupt-renode-test-automation).
 
-See anything you'd like to change? Submit a pull request or open an issue at
-[GitHub](https://github.com/memfault/interrupt)
+{% include submit-pr.html %}
 
 {:.no_toc}
 

--- a/_posts/2020-07-23-building-drivers-on-zephyr.md
+++ b/_posts/2020-07-23-building-drivers-on-zephyr.md
@@ -588,7 +588,7 @@ Curious about the nRF9160 Feather? It's open-source and is available for pre-ord
 
 You can [check it out here.][nrf9160-feather]
 
-See anything you’d like to change? Submit a pull request or open an issue at [GitHub](https://github.com/memfault/interrupt).
+{% include submit-pr.html %}
 
 {:.no_toc}
 ## References

--- a/_posts/2020-07-29-cortex-m-debug-monitor.md
+++ b/_posts/2020-07-29-cortex-m-debug-monitor.md
@@ -29,8 +29,7 @@ example of installing breakpoints and single-stepping on a running device!
 > In my opinion, DebugMonitor handling is an underutilized feature that can be applied creatively
 > for a variety of debug use cases. I hope by the end of this article I can convince you of this as well!
 
-_Like Interrupt? [Subscribe](http://eepurl.com/gpRedv) to get our latest
-posts straight to your mailbox_
+{% include newsletter.html %}
 
 {:.no_toc}
 
@@ -667,7 +666,7 @@ about creative ways the feature can be leveraged.
 Have you used the monitor mode debugging for any projects you've worked on. If so, we'd love to hear
 what you used it for in the discussion area below!
 
-See anything you'd like to change? Submit a pull request or open an issue at [Github](https://github.com/memfault/interrupt)
+{% include submit-pr.html %}
 
 {:.no_toc}
 

--- a/_posts/2020-08-04-firmware-logs-stack-trace.md
+++ b/_posts/2020-08-04-firmware-logs-stack-trace.md
@@ -3,7 +3,9 @@ title: Parsing Logs Messages for Instant Crash Analysis
 description: A stack trace for embedded software. Get all the information you need to debug firmware crashes right into your logs, in a few easy steps.
 image: /img/logs-stack-trace/colorful_stack_unbundling.gif
 author: cyril
+toc: true
 ---
+
 
 <!-- excerpt start -->
 
@@ -15,8 +17,7 @@ In this post, I will introduce a few tools to implement a beautiful boosted logg
 
 > This post was originally published on [Cyril's website](http://www.cyrilfougeray.com/2020/07/27/firmware-logs-with-stack-trace.html).
 
-_Like Interrupt? [Subscribe](http://eepurl.com/gpRedv) to get our latest posts
-straight to your mailbox_
+{% include newsletter.html %}
 
 ![Colorful stack]({% img_url logs-stack-trace/colorful_stack_unbundling.gif %})
 

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -7,3 +7,4 @@ $linkedin-color: #0077B5;
 
 $blue: #141443;
 $gray: rgba(20, 24, 69, 0.15);
+$white: white;

--- a/_sass/_variables.scss
+++ b/_sass/_variables.scss
@@ -1,0 +1,9 @@
+$orange-color: #f66a0a !default;
+$twitter-color: #1da1f2;
+$github-color: #000000;
+$rss-color: $orange-color;
+$linkedin-color: #0077B5;
+
+
+$blue: #141443;
+$gray: rgba(20, 24, 69, 0.15);

--- a/_sass/custom.scss
+++ b/_sass/custom.scss
@@ -1,12 +1,10 @@
 /*- Custom style -*/
 
+
 /*- colors -*/
 
-$orange-color: #f66a0a !default;
-$twitter-color: #1da1f2;
-$github-color: #000000;
-$rss-color: $orange-color;
-$linkedin-color: #0077B5;
+@import "variables";
+@import "modules/toc";
 
 /*- formatting -*/
 

--- a/_sass/custom.scss
+++ b/_sass/custom.scss
@@ -4,7 +4,6 @@
 /*- colors -*/
 
 @import "variables";
-@import "modules/toc";
 
 /*- formatting -*/
 

--- a/_sass/mixin.scss
+++ b/_sass/mixin.scss
@@ -39,3 +39,24 @@
   padding: 72px 0;
   text-align: center;
 }
+
+
+@mixin setFeatured($name) {
+    background-color: $blue;
+    color: $white;
+    padding: 1rem;
+    margin-bottom: 1rem;
+    .#{$name}-link {
+      font-weight: bold !important;
+      color: white;
+      &:hover,
+      &:focus,
+      &:active,
+      &visited {
+        color: white;
+      }
+    }
+    .#{$name}-content {
+      margin-bottom: 0;
+    }
+}

--- a/_sass/modules/_newsletter.scss
+++ b/_sass/modules/_newsletter.scss
@@ -1,0 +1,4 @@
+.newsletter {
+  @include setFeatured(newsletter);
+  font-style: italic;
+}

--- a/_sass/modules/_submit_pr.scss
+++ b/_sass/modules/_submit_pr.scss
@@ -1,0 +1,3 @@
+.submit-pr {
+  @include setFeatured(submit-pr);
+}

--- a/_sass/modules/_toc.scss
+++ b/_sass/modules/_toc.scss
@@ -1,7 +1,4 @@
 #table-of-contents {
-  background-color: $gray;
-  padding-left: 2rem;
-  color: $blue;
   padding-bottom: 0;
   margin: 0;
 }
@@ -11,6 +8,7 @@
   color: $blue;
   padding-left: 2rem;
   margin-left: 0;
+  padding-top: 1rem;
   padding-bottom: 1rem;
   margin-bottom: 0;
 }

--- a/_sass/modules/_toc.scss
+++ b/_sass/modules/_toc.scss
@@ -1,8 +1,6 @@
-@import "variables";
-
 #table-of-contents {
   background-color: $gray;
-  padding-left: 10px;
+  padding-left: 2rem;
   color: $blue;
   padding-bottom: 0;
   margin: 0;

--- a/_sass/modules/_toc.scss
+++ b/_sass/modules/_toc.scss
@@ -1,0 +1,18 @@
+@import "variables";
+
+#table-of-contents {
+  background-color: $gray;
+  padding-left: 10px;
+  color: $blue;
+  padding-bottom: 0;
+  margin: 0;
+}
+
+#markdown-toc {
+  background-color: $gray;
+  color: $blue;
+  padding-left: 2rem;
+  margin-left: 0;
+  padding-bottom: 1rem;
+  margin-bottom: 0;
+}

--- a/css/main.scss
+++ b/css/main.scss
@@ -4,3 +4,6 @@
 
 //Import
 @import "base", "mixin", "typography", "tag", "layout", "syntax.scss", "custom.scss";
+@import "modules/toc";
+@import "modules/newsletter";
+@import "modules/submit_pr";


### PR DESCRIPTION
### Contribution description
I would like to propose the following changes. While we are reading the articles, there is always a table of content and I thought that probably we could highlight this block in some manner, I am not so sure about the colors but it can look something like this: 

![image](https://user-images.githubusercontent.com/1287883/90301951-4481fc80-de79-11ea-8d9c-3e1b81e893d2.png)

In this way, the embedded developer can clearly identify where the main points are summarized. 

On the other hand, I noticed that in the posts there are two content that repeat quite often which is the invite to the newsletter and the to submit a pull request. As the blog will increase the posts more and more, I think we can take those content and set them a single place where we can edit it and then place it wherever is required. This is a table that represents the changes:

|                                                    Past                                                    |              Now              |
|:----------------------------------------------------------------------------------------------------------:|:-----------------------------:|
|                         `See anything you'd like to change? Submit a pull request!`                        |  {% include submit-pr.html %} |
| `_Like Interrupt? [Subscribe](http://eepurl.com/gpRedv) to get our latest posts straight to your mailbox_` | {% include newsletter.html %} |

This changes translate into:

![image](https://user-images.githubusercontent.com/1287883/90302163-c7578700-de7a-11ea-91de-076667244c84.png)

![image](https://user-images.githubusercontent.com/1287883/90302168-d3434900-de7a-11ea-9a44-cc253431a9c3.png)

What do you think about it? 
