### PR TITLE
Set acknowledge bit to 'NACK' in I2C Address Issues

### DIFF
--- a/_posts/2020-01-22-i2c-in-a-nutshell.md
+++ b/_posts/2020-01-22-i2c-in-a-nutshell.md
@@ -310,9 +310,9 @@ Often times, you will see the following on your logic analyzer:
 <script type="WaveDrom">
 { signal : 
   [
-    { name: "SDA",  wave: "101.0.1.010.1."},
+    { name: "SDA",  wave: "101.0.1.01.01."},
     { name: "SCL",  wave: "1.n.........h."},
-    { name: "bits", wave: "x==========x=x",  data: ["S", "1", "1", "0", "0", "1", "1","0","1","0","P"]},
+    { name: "bits", wave: "x==========x=x",  data: ["S", "1", "1", "0", "0", "1", "1","0","1","1","P"]},
     { name: "data", wave: "x.=......==x..", data: ["Address: 0x66","W", "N"]}
   ],
 }


### PR DESCRIPTION
While reading through the "I2C in a Nutshell" post I noticed an error in the waveform under the section titled "I2C Address Issues".

The Acknowledge-bit in the example waveform is supposed to be in the in the NACK state but is a 0, the ACK state. So I've corrected it in the waveform. I'm pretty sure NACK == 1, and ACK == 0, but I am new to I2C :D 

Thanks for the great article :) 