### PR TITLE
Faster Debugging with Watchpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .DS_Store
 _site
 vendor
+example/*/build

--- a/_config.yml
+++ b/_config.yml
@@ -42,6 +42,9 @@ plugins:
 tag_page: '/tags/'
 category_page: '/categories/'
 
+sass:
+    style: compressed
+    
 # Options
 custom_nav_footer: true
 reverse: false

--- a/_posts/2020-09-16-cortex-m-watchpoints.md
+++ b/_posts/2020-09-16-cortex-m-watchpoints.md
@@ -56,7 +56,7 @@ $ JLinkGDBServer  -if swd -device nRF52840_xxAA  -nogui
 
 ```bash
 $ git clone https://github.com/memfault/interrupt.git
-$ cd examples/watchpoint
+$ cd example/watchpoints
 
 # Build
 $ make
@@ -694,8 +694,6 @@ For the typical, "data address" watchpoint we have talked about so far in the ar
 If we have configured the `DWT_FUNCTION` register to look for a data address access, this register simply holds that address.
 
 #### Comparator Mask registers, DWT_MASK, 0xE0001024 + 16n
-
-![]({% img_url watchpoint/dwt-mask.png %})
 
 The setting in the `MASK` defines the number of bits to ignore when performing a comparison. The maximum mask size is implementation defined but you can easily figure out the max size by writing 0x1F to the field and seeing which bits remain set. For example, on the NRF52:
 


### PR DESCRIPTION
What a great article @chrisc11 congrats :D While reading it I found out some catchs. 

I think we can hide the build folder that it's created from example folder? I am not sure if `build` name folder is used for all entire examples. What do you think? 

Aside of that, it looks like an image wasn't pushed to the repo?

On the top of that, I've enable compressed option so instead of loading the css files with comments and in that way we can speed up load process on the site. 

