### PR TITLE
Dockerize interrupt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
-FROM ruby:2.7
+FROM ruby:2.7-alpine
+
+RUN apk --update add --no-cache --virtual build-dependencies build-base bash
 
 WORKDIR /memfault/interrupt
 
-ENTRYPOINT ["./interrupt-cli"]
+ENTRYPOINT ["./entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM ruby:2.7
+
+WORKDIR /memfault/interrupt
+
+ENTRYPOINT ["./interrupt-cli"]

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker build --rm --tag interrupt:v1.0.0 --file Dockerfile .

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
-set -o errexit
-set -o nounset
-set -o pipefail
+set -euo pipefail
 
 function help()
 {
@@ -24,7 +22,7 @@ RUN=false
 
 ! PARAMS=$(getopt --options=$OPTSTR --longoptions=$LONGOPTS --name "$0"  -- "$@")
 
-if [ ${PIPESTATUS[0]} -ne 0 ]; then
+if [ "${PIPESTATUS[0]}" -ne 0 ]; then
     exit 2
 fi
 
@@ -84,5 +82,5 @@ if [ $RUN = true ]; then
   LAUNCH_INTERRUPT+="RUBYOPT='-W0' bundle exec jekyll serve -D"
 fi
 
-echo $LAUNCH_INTERRUPT
-eval $LAUNCH_INTERRUPT
+echo "$LAUNCH_INTERRUPT"
+eval "$LAUNCH_INTERRUPT"

--- a/interrupt-cli
+++ b/interrupt-cli
@@ -1,0 +1,88 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+function help()
+{
+  echo "\
+Usage: interrupt-cli [--build] [--run]
+  Build, and run interrupt blog
+
+Options:
+  -b, --build           Build and install required packages.
+  -r, --run             Launch blog at http://localhost:4000.
+  -h, --help            Display this help and exit.
+"
+}
+
+OPTSTR=brh
+LONGOPTS=build,run,help
+
+BUILD=false
+RUN=false
+
+! PARAMS=$(getopt --options=$OPTSTR --longoptions=$LONGOPTS --name "$0"  -- "$@")
+
+if [ ${PIPESTATUS[0]} -ne 0 ]; then
+    exit 2
+fi
+
+eval set -- "$PARAMS"
+
+while true; do
+  case "$1" in
+    -h|--help)
+      shift
+      help
+      exit 0
+      ;;
+    -b|--build)
+      BUILD=true
+      shift 1
+      ;;
+    -r|--run)
+      RUN=true
+      shift 1
+      ;;
+    --)
+      shift
+      break
+      ;;
+    *)
+      echo "Error found while parsing arguments!"
+      exit 3
+      ;;
+  esac
+done
+
+
+if [ $# -ne 0 ]; then
+    echo "$0: Option \"$1\" not supported"
+    exit 4
+fi
+
+LAUNCH_INTERRUPT=""
+CONCATENATION_IS_REQUIRED=false
+
+concatenate_if_required()
+{
+  if [ $CONCATENATION_IS_REQUIRED = true ]; then
+      LAUNCH_INTERRUPT+=" && "
+  fi
+}
+
+if [ $BUILD = true ]; then
+  concatenate_if_required
+  LAUNCH_INTERRUPT+="bundle install"
+  CONCATENATION_IS_REQUIRED=true
+fi
+
+
+if [ $RUN = true ]; then
+  concatenate_if_required
+  LAUNCH_INTERRUPT+="RUBYOPT='-W0' bundle exec jekyll serve -D"
+fi
+
+echo $LAUNCH_INTERRUPT
+eval $LAUNCH_INTERRUPT

--- a/interrupt-server.sh
+++ b/interrupt-server.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker run -it --mount type=bind,source=$(pwd),target=/memfault/interrupt --name interrupt --net host --rm --tty interrupt:v1.0.0 "$@"

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Interrupt
 
-Interrupt is a community for embedded software makers and professionals alike. 
+Interrupt is a community for embedded software makers and professionals alike.
 
 - [Interrupt Slack Channel](https://interrupt-slack.herokuapp.com/)
 - [Interrupt Discourse](https://community.memfault.com/)
@@ -15,7 +15,9 @@ To submit your content, either email us at interrupt@memfault.com, or open a pul
 
 See [Contributing](https://interrupt.memfault.com/blog/contributing) for more information.
 
-## Running locally
+## Running
+
+### locally
 
 Follow the instructions in the [Jekyll quickstart guide](https://jekyllrb.com/docs/) to install Ruby and Jekyll and bundler.
 
@@ -25,6 +27,18 @@ $ git clone https://github.com/memfault/interrupt.git
 $ cd interrupt
 $ bundle install
 $ bundle exec jekyll serve -D
+```
+
+### with docker
+
+Follow the instructions in the [Install Docker Engine](https://docs.docker.com/engine/install/) according to your operating system.
+
+Clone the repo, build and run:
+```
+$ git clone https://github.com/memfault/interrupt.git
+$ cd interrupt
+$ ./build.sh
+$ ./interrupt-server.sh --run --build
 ```
 
 ## Acknowledgements


### PR DESCRIPTION
### Contribution description

One of the great features that come with Interrupt is the fact that there are different authors that share their experiences along a diverse set of embedded topics. I think that to write an article, the embedded developer should clone an instance of interrupt blog and set up a jekyll local server. This imply to install all required packages on local machine but wouldn't be great if we can have a way to support a dockerize interrupt version so that embedded developers, if they already have docker installed, can take advantage of this and start creating their article drafts over the container? 

For that I've created a draft PR that contain the changes to be made on repo in order to build an interrupt docker image and write the drafts article over the container.

It would be great to read your feedback on this. 
