### PR TITLE
Discourse comment embedded fix

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,6 +2,7 @@
   <!-- Meta -->
   <meta charset="UTF-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
+  <meta name="referrer" content="no-referrer-when-downgrade">
 
   {% seo %}
 


### PR DESCRIPTION
Needed to add `<meta name="referrer"
content="no-referrer-when-downgrade">` according to the comment post:

https://meta.discourse.org/t/no-referer-no-embedding/163524/4

Also needed to adjust admin embedded settings as the post above
describes.

