### PR TITLE
fix libc symbol not defined compile error

### DIFF
--- a/example/breakpoint/Makefile
+++ b/example/breakpoint/Makefile
@@ -1,10 +1,18 @@
 ROOT_DIR := $(abspath .)
 BUILD_DIR  := $(ROOT_DIR)/build
-Q ?= @
+
+ifeq ($(V), 1)
+Q =
+else
+Q = @
+endif
 
 FREERTOS_ROOT_DIR := $(ROOT_DIR)/freertos_kernel
 
-COMPILER ?= arm-none-eabi-gcc
+COMPILER ?= arm-none-eabi-
+
+CC = $(COMPILER)gcc
+DUMP = $(COMPILER)objdump
 
 PROJECT_SRC_DIR = $(ROOT_DIR)/src
 
@@ -41,7 +49,7 @@ TARGET ?= nrf52
 LDSCRIPT = $(ROOT_DIR)/$(TARGET).ld
 TARGET_ELF = $(BUILD_DIR)/$(TARGET).elf
 
-LDFLAGS += -T$(LDSCRIPT)
+LDFLAGS += -T$(LDSCRIPT) --specs=nano.specs
 LDFLAGS += -Wl,-Map,$(BUILD_DIR)/$(TARGET).map
 
 DEP_DIR = $(BUILD_DIR)/dep
@@ -59,8 +67,10 @@ clean:
 
 $(TARGET_ELF): $(OBJ_FILES) $(LDSCRIPT)
 	@echo "Linking library"
-	@arm-none-eabi-gcc $(CFLAGS) $(LDFLAGS) $(OBJ_FILES) -o $@ -Wl,-lc -Wl,-lgcc
+	$(Q) $(CC) $(CFLAGS) $(LDFLAGS) $(OBJ_FILES) -o $@ -Wl,-lc -Wl,-lgcc
 	@echo "Generated $(patsubst $(ROOT_DIR)/%,%,$@)"
+	$(Q) $(DUMP) -S $@ > $@.asm
+	@echo "Generated $(patsubst $(ROOT_DIR)/%,%,$@.asm)"
 
 $(BUILD_DIR):
 	@mkdir -p $(BUILD_DIR)
@@ -73,4 +83,4 @@ $(OBJ_FILES): $(SRC_FILES) Makefile
 $(BUILD_DIR)/%.o: $(ROOT_DIR)/%.c | $(BUILD_DIR) $(DEP_DIR) $(FREERTOS_PORT_ROOT)
 	@echo "Compiling $(patsubst $(ROOT_DIR)/%,%,$<)"
 	@mkdir -p $(dir $@)
-	$(Q) arm-none-eabi-gcc $(DEP_CFLAGS) $(CFLAGS) $(INCLUDE_PATHS) -c -o $@ $<
+	$(Q) $(CC) $(DEP_CFLAGS) $(CFLAGS) $(INCLUDE_PATHS) -c -o $@ $<

--- a/example/debugmon/Makefile
+++ b/example/debugmon/Makefile
@@ -1,10 +1,18 @@
 ROOT_DIR := $(abspath .)
 BUILD_DIR  := $(ROOT_DIR)/build
-Q ?= @
+
+ifeq ($(V), 1)
+Q =
+else
+Q = @
+endif
 
 FREERTOS_ROOT_DIR := $(ROOT_DIR)/freertos_kernel
 
-COMPILER ?= arm-none-eabi-gcc
+COMPILER ?= arm-none-eabi-
+
+CC = $(COMPILER)gcc
+DUMP = $(COMPILER)objdump
 
 PROJECT_SRC_DIR = $(ROOT_DIR)/src
 
@@ -37,12 +45,13 @@ CFLAGS += \
   -Werror \
   -fdebug-prefix-map=$(ROOT_DIR)=. \
   -Os
+  # --specs=nano.specs
 
 TARGET ?= nrf52
 LDSCRIPT = $(ROOT_DIR)/$(TARGET).ld
 TARGET_ELF = $(BUILD_DIR)/$(TARGET).elf
 
-LDFLAGS += -T$(LDSCRIPT)
+LDFLAGS += -T$(LDSCRIPT) --specs=nano.specs
 LDFLAGS += -Wl,-Map,$(BUILD_DIR)/$(TARGET).map
 
 DEP_DIR = $(BUILD_DIR)/dep
@@ -60,8 +69,10 @@ clean:
 
 $(TARGET_ELF): $(OBJ_FILES) $(LDSCRIPT)
 	@echo "Linking library"
-	@arm-none-eabi-gcc $(CFLAGS) $(LDFLAGS) $(OBJ_FILES) -o $@ -Wl,-lc -Wl,-lgcc
+	$(Q) $(CC)  $(CFLAGS) $(LDFLAGS) $(OBJ_FILES) -o $@ -Wl,-lc -Wl,-lgcc
 	@echo "Generated $(patsubst $(ROOT_DIR)/%,%,$@)"
+	$(Q) $(DUMP) -S $@ > $@.asm
+	@echo "Generated $(patsubst $(ROOT_DIR)/%,%,$@.asm)"
 
 $(BUILD_DIR):
 	@mkdir -p $(BUILD_DIR)
@@ -74,4 +85,4 @@ $(OBJ_FILES): $(SRC_FILES) Makefile
 $(BUILD_DIR)/%.o: $(ROOT_DIR)/%.c | $(BUILD_DIR) $(DEP_DIR) $(FREERTOS_PORT_ROOT)
 	@echo "Compiling $(patsubst $(ROOT_DIR)/%,%,$<)"
 	@mkdir -p $(dir $@)
-	$(Q) arm-none-eabi-gcc $(DEP_CFLAGS) $(CFLAGS) $(INCLUDE_PATHS) -c -o $@ $<
+	$(Q) $(CC) $(DEP_CFLAGS) $(CFLAGS) $(INCLUDE_PATHS) -c -o $@ $<


### PR DESCRIPTION
Hi, I find this blog by accident and learn a lot from here. When I try to compile the example demo of `breakpoint ` and `debugmon` I get a error message at link stage.The error information is here:

```
Linking library
/usr/lib/gcc/arm-none-eabi/9.2.1/../../../arm-none-eabi/bin/ld: /usr/lib/gcc/arm-none-eabi/9.2.1/../../../arm-none-eabi/lib/thumb/v7e-m+fp/hard/libc.a(lib_a-abort.o): in function `abort':
/build/newlib-CVVEyx/newlib-3.3.0/build/arm-none-eabi/thumb/v7e-m+fp/hard/newlib/libc/stdlib/../../../../../../../../newlib/libc/stdlib/abort.c:59: undefined reference to `_exit'

```
My platform information:
```
kernel version: 5.8.0-28
gcc version: arm-none-eabi-gcc(15:9-2019-q4-0ubuntu1) 9.2.1 20191025(release)
```

After some search I found that is because these demo use some function from libc by include head file like `stdio.h`, and the lack symbol like `_exit` is system call which the function in libc invoke. But for these demo there are no need to use a operating system so there are no system call at all. I found the best way to fix it is add a `--sepecs=nano.specs` at the link flag and it work at my platform. I also make some change to Makefile to let them more useful.
