### PR TITLE
Fix urlencoding post titles for social links

### DIFF
--- a/_includes/share-buttons.html
+++ b/_includes/share-buttons.html
@@ -13,19 +13,19 @@
             </svg>
         </div>
 
-        <div class="twitter" title="Share this on Twitter" onclick="window.open(`https://twitter.com/share?url={{ site.url }}{{ site.baseurl }}{{ pageurl }}&text={{ page.title | replace:"'", ""  }}`);">
+        <div class="twitter" title="Share this on Twitter" onclick="window.open(`https://twitter.com/share?url={{ site.url }}{{ site.baseurl }}{{ pageurl }}&text={{ page.title | url_encode  }}`);">
             <svg viewBox="0 0 1792 1792" xmlns="http://www.w3.org/2000/svg">
                 <path d="M1684 408q-67 98-162 167 1 14 1 42 0 130-38 259.5t-115.5 248.5-184.5 210.5-258 146-323 54.5q-271 0-496-145 35 4 78 4 225 0 401-138-105-2-188-64.5t-114-159.5q33 5 61 5 43 0 85-11-112-23-185.5-111.5t-73.5-205.5v-4q68 38 146 41-66-44-105-115t-39-154q0-88 44-163 121 149 294.5 238.5t371.5 99.5q-8-38-8-74 0-134 94.5-228.5t228.5-94.5q140 0 236 102 109-21 205-78-37 115-142 178 93-10 186-50z"/>
             </svg>
         </div>
 
-        <div class="linkedin" title="Share this on Linkedin" onclick="window.open(`https://www.linkedin.com/shareArticle?mini=true&url={{ site.url }}{{ site.baseurl }}{{ pageurl }}&title={{ page.title | replace:"'", ""  }}&summary=&source={{ site.url }}{{ site.baseurl }}{{ pageurl }}`);">
+        <div class="linkedin" title="Share this on Linkedin" onclick="window.open(`https://www.linkedin.com/shareArticle?mini=true&url={{ site.url }}{{ site.baseurl }}{{ pageurl }}&title={{ page.title | url_encode  }}&summary=&source={{ site.url }}{{ site.baseurl }}{{ pageurl }}`);">
             <svg viewBox="0 0 1792 1792" xmlns="http://www.w3.org/2000/svg">
                 <path d="M477 625v991h-330v-991h330zm21-306q1 73-50.5 122t-135.5 49h-2q-82 0-132-49t-50-122q0-74 51.5-122.5t134.5-48.5 133 48.5 51 122.5zm1166 729v568h-329v-530q0-105-40.5-164.5t-126.5-59.5q-63 0-105.5 34.5t-63.5 85.5q-11 30-11 81v553h-329q2-399 2-647t-1-296l-1-48h329v144h-2q20-32 41-56t56.5-52 87-43.5 114.5-15.5q171 0 275 113.5t104 332.5z"/>
             </svg>
         </div>
 
-        <div class="reddit" title="Share this on Reddit" onclick="window.open(`http://www.reddit.com/submit?url={{ site.url }}{{ site.baseurl }}{{ pageurl }}&title={{ page.title | replace:"'", "" }}&summary=&source=`, 'newwindow');">
+        <div class="reddit" title="Share this on Reddit" onclick="window.open(`http://www.reddit.com/submit?url={{ site.url }}{{ site.baseurl }}{{ pageurl }}&title={{ page.title | url_encode }}&summary=&source=`, 'newwindow');">
             <svg id="Bold" enable-background="new 0 0 24 24" height="512" viewBox="0 0 24 24" width="512" xmlns="http://www.w3.org/2000/svg">
                 <path d="m21.325 9.308c-.758 0-1.425.319-1.916.816-1.805-1.268-4.239-2.084-6.936-2.171l1.401-6.406 4.461 1.016c0 1.108.89 2.013 1.982 2.013 1.113 0 2.008-.929 2.008-2.038s-.889-2.038-2.007-2.038c-.779 0-1.451.477-1.786 1.129l-4.927-1.108c-.248-.067-.491.113-.557.365l-1.538 7.062c-2.676.113-5.084.928-6.895 2.197-.491-.518-1.184-.837-1.942-.837-2.812 0-3.733 3.829-1.158 5.138-.091.405-.132.837-.132 1.268 0 4.301 4.775 7.786 10.638 7.786 5.888 0 10.663-3.485 10.663-7.786 0-.431-.045-.883-.156-1.289 2.523-1.314 1.594-5.115-1.203-5.117zm-15.724 5.41c0-1.129.89-2.038 2.008-2.038 1.092 0 1.983.903 1.983 2.038 0 1.109-.89 2.013-1.983 2.013-1.113.005-2.008-.904-2.008-2.013zm10.839 4.798c-1.841 1.868-7.036 1.868-8.878 0-.203-.18-.203-.498 0-.703.177-.18.491-.18.668 0 1.406 1.463 6.07 1.488 7.537 0 .177-.18.491-.18.668 0 .207.206.207.524.005.703zm-.041-2.781c-1.092 0-1.982-.903-1.982-2.011 0-1.129.89-2.038 1.982-2.038 1.113 0 2.008.903 2.008 2.038-.005 1.103-.895 2.011-2.008 2.011z"/>
             </svg>

--- a/_includes/share-buttons.html
+++ b/_includes/share-buttons.html
@@ -4,6 +4,12 @@
     {% assign pageurl = page.url %}
 {% endif %}
 
+{% if page.title == nil %}
+    {% assign pagetitle = page.title %}
+{% else %}
+    {% assign pagetitle = page.title | url_encode %}
+{% endif %}
+
 <div class="share-buttons-wrapper">
     <h3>Share on: </h3>
     <div id="share-buttons">
@@ -13,19 +19,19 @@
             </svg>
         </div>
 
-        <div class="twitter" title="Share this on Twitter" onclick="window.open(`https://twitter.com/share?url={{ site.url }}{{ site.baseurl }}{{ pageurl }}&text={{ page.title | url_encode  }}`);">
+        <div class="twitter" title="Share this on Twitter" onclick="window.open(`https://twitter.com/share?url={{ site.url }}{{ site.baseurl }}{{ pageurl }}&text={{ pagetitle }}`);">
             <svg viewBox="0 0 1792 1792" xmlns="http://www.w3.org/2000/svg">
                 <path d="M1684 408q-67 98-162 167 1 14 1 42 0 130-38 259.5t-115.5 248.5-184.5 210.5-258 146-323 54.5q-271 0-496-145 35 4 78 4 225 0 401-138-105-2-188-64.5t-114-159.5q33 5 61 5 43 0 85-11-112-23-185.5-111.5t-73.5-205.5v-4q68 38 146 41-66-44-105-115t-39-154q0-88 44-163 121 149 294.5 238.5t371.5 99.5q-8-38-8-74 0-134 94.5-228.5t228.5-94.5q140 0 236 102 109-21 205-78-37 115-142 178 93-10 186-50z"/>
             </svg>
         </div>
 
-        <div class="linkedin" title="Share this on Linkedin" onclick="window.open(`https://www.linkedin.com/shareArticle?mini=true&url={{ site.url }}{{ site.baseurl }}{{ pageurl }}&title={{ page.title | url_encode  }}&summary=&source={{ site.url }}{{ site.baseurl }}{{ pageurl }}`);">
+        <div class="linkedin" title="Share this on Linkedin" onclick="window.open(`https://www.linkedin.com/shareArticle?mini=true&url={{ site.url }}{{ site.baseurl }}{{ pageurl }}&title={{ pagetitle }}&summary=&source={{ site.url }}{{ site.baseurl }}{{ pageurl }}`);">
             <svg viewBox="0 0 1792 1792" xmlns="http://www.w3.org/2000/svg">
                 <path d="M477 625v991h-330v-991h330zm21-306q1 73-50.5 122t-135.5 49h-2q-82 0-132-49t-50-122q0-74 51.5-122.5t134.5-48.5 133 48.5 51 122.5zm1166 729v568h-329v-530q0-105-40.5-164.5t-126.5-59.5q-63 0-105.5 34.5t-63.5 85.5q-11 30-11 81v553h-329q2-399 2-647t-1-296l-1-48h329v144h-2q20-32 41-56t56.5-52 87-43.5 114.5-15.5q171 0 275 113.5t104 332.5z"/>
             </svg>
         </div>
 
-        <div class="reddit" title="Share this on Reddit" onclick="window.open(`http://www.reddit.com/submit?url={{ site.url }}{{ site.baseurl }}{{ pageurl }}&title={{ page.title | url_encode }}&summary=&source=`, 'newwindow');">
+        <div class="reddit" title="Share this on Reddit" onclick="window.open(`http://www.reddit.com/submit?url={{ site.url }}{{ site.baseurl }}{{ pageurl }}&title={{ pagetitle }}&summary=&source=`, 'newwindow');">
             <svg id="Bold" enable-background="new 0 0 24 24" height="512" viewBox="0 0 24 24" width="512" xmlns="http://www.w3.org/2000/svg">
                 <path d="m21.325 9.308c-.758 0-1.425.319-1.916.816-1.805-1.268-4.239-2.084-6.936-2.171l1.401-6.406 4.461 1.016c0 1.108.89 2.013 1.982 2.013 1.113 0 2.008-.929 2.008-2.038s-.889-2.038-2.007-2.038c-.779 0-1.451.477-1.786 1.129l-4.927-1.108c-.248-.067-.491.113-.557.365l-1.538 7.062c-2.676.113-5.084.928-6.895 2.197-.491-.518-1.184-.837-1.942-.837-2.812 0-3.733 3.829-1.158 5.138-.091.405-.132.837-.132 1.268 0 4.301 4.775 7.786 10.638 7.786 5.888 0 10.663-3.485 10.663-7.786 0-.431-.045-.883-.156-1.289 2.523-1.314 1.594-5.115-1.203-5.117zm-15.724 5.41c0-1.129.89-2.038 2.008-2.038 1.092 0 1.983.903 1.983 2.038 0 1.109-.89 2.013-1.983 2.013-1.113.005-2.008-.904-2.008-2.013zm10.839 4.798c-1.841 1.868-7.036 1.868-8.878 0-.203-.18-.203-.498 0-.703.177-.18.491-.18.668 0 1.406 1.463 6.07 1.488 7.537 0 .177-.18.491-.18.668 0 .207.206.207.524.005.703zm-.041-2.781c-1.092 0-1.982-.903-1.982-2.011 0-1.129.89-2.038 1.982-2.038 1.113 0 2.008.903 2.008 2.038-.005 1.103-.895 2.011-2.008 2.011z"/>
             </svg>

--- a/_plugins/url_encode.rb
+++ b/_plugins/url_encode.rb
@@ -1,0 +1,12 @@
+require 'liquid'
+require 'uri'
+
+# Percent encoding for URI conforming to RFC 3986.
+# Ref: http://tools.ietf.org/html/rfc3986#page-12
+module URLEncoding
+  def url_encode(url)
+    return URI.escape(url, Regexp.new("[^#{URI::PATTERN::UNRESERVED}]"))
+  end
+end
+
+Liquid::Template.register_filter(URLEncoding)


### PR DESCRIPTION
Replacing `'` with nothing wasn't the right approach. Just need to URL encode the items. Unfortunately no `url_encode` built in. I think it may be in a future Jekyll version though?