### PR TITLE
fix some typo's in posts

### DIFF
--- a/_posts/2019-06-25-how-to-write-linker-scripts-for-firmware.md
+++ b/_posts/2019-06-25-how-to-write-linker-scripts-for-firmware.md
@@ -194,7 +194,7 @@ Our linker script concerns itself with two more things:
 By convention, we name those sections as follow:
 
 1. `.text` for code & constants
-2. `.bss` for unintialized data
+2. `.bss` for uninitialized data
 3. `.stack` for our stack
 4. `.data` for initialized data
 
@@ -231,7 +231,7 @@ SYMBOL TABLE:
 no symbols
 ```
 
-No symbols! While the linker is able to make asumptions that will allow it to
+No symbols! While the linker is able to make assumptions that will allow it to
 link in symbols with little information, but it at least needs to know either
 what the entry point should be, or what symbols to put in the text section.
 
@@ -364,7 +364,7 @@ SECTION {
 ```
 
 You'll note that the `.bss` section also includes `*(COMMON)`. This is a
-special input section where the compiler puts global unitialized variables that
+special input section where the compiler puts global uninitialized variables that
 go beyond file scope. `int foo;` goes there, while `static int foo;` does not.
 This allows the linker to merge multiple definitions into one symbol if they
 have the same name.
@@ -383,7 +383,7 @@ Procedure Call Standards
 In order to achieve these goals, we turn to a special variable `.`, also known
 as the "location counter". The location counter tracks the current offset into a
 given memory region. As sections are added, the location counter increments
-accordingly. You can force alignemnt or gaps by setting the location counter
+accordingly. You can force alignment or gaps by setting the location counter
 forward. You may not set it backwards, and the linker will throw an error if you
 try.
 
@@ -433,7 +433,7 @@ two part: <VMA> AT <LMA>. In our case it looks like this:
 } > ram AT > rom  /* "> ram" is the VMA, "> rom" is the LMA */
 ```
 
-Note that instead of appending a section to a memory region, you could also explicity
+Note that instead of appending a section to a memory region, you could also explicitly
 specify an address like so:
 
 ```

--- a/_posts/2019-10-30-cortex-m-rtos-context-switching.md
+++ b/_posts/2019-10-30-cortex-m-rtos-context-switching.md
@@ -170,7 +170,7 @@ Excerpt from "B5.2.3 MSR"[^2]:
 > to unprivileged execution, software must issue an ISB instruction to ensure instruction fetch
 > correctness.
 
-For context switching, one of the the most important special registers is the `CONTROL`
+For context switching, one of the most important special registers is the `CONTROL`
 register. Bits in the register read-as-zero unless they are implemented. The
 ARMv8-M architecture[^4] has the largest number of optional extensions so the most complete assignment
 set one will see is:
@@ -193,7 +193,7 @@ where
 
 ### Stack Pointers
 
-The Cortex-M architecture implements two stacks known as the _Main Stack_ (tracked in the `msp` register) and the the
+The Cortex-M architecture implements two stacks known as the _Main Stack_ (tracked in the `msp` register) and the
 _Process Stack_ (tracked in the `psp` register). On reset, the **MSP** is always active and its initial value is derived
 from the first word in the vector table. When a stack pointer is "active", its current value will
 be returned when the `sp` register is accessed.
@@ -443,7 +443,7 @@ Resetting target
 Let's start by looking at the code that deals with context switching itself. Once we understand
 that, we will cycle back to how the scheduler itself is started and tasks are created.
 
-The **FreeRTOS** scheduler works by utilizing the the built in **SysTick** and **PendSV** interrupts. The
+The **FreeRTOS** scheduler works by utilizing the built in **SysTick** and **PendSV** interrupts. The
 **SysTick** is configured to fire periodically. Each time it fires, a check is performed to see if a
 context switch is required by calling `xTaskIncrementTick`:
 

--- a/_posts/2020-12-08-seamless-firmware-with-platformio.md
+++ b/_posts/2020-12-08-seamless-firmware-with-platformio.md
@@ -177,7 +177,7 @@ from my IDE so I can use trusty old Vim.
 
 In this next section, I will walk you through installing the CLI, starting a
 project, adding some libraries, and compiling your work. All code is available
-in the the [Interrupt Github repository](https://github.com/memfault/interrupt),
+in the [Interrupt Github repository](https://github.com/memfault/interrupt),
 under `example/platformio`.
 
 ### Installing the CLI


### PR DESCRIPTION
while reading, i found some typo's.

i also saw an unfinished sentence at https://interrupt.memfault.com/blog/how-to-write-linker-scripts-for-firmware, just below the "Variables" section: "In the first post, our ResetHandler relied on seemingly magic variables to know the address of each of our sections of memory. It turns out, those variable came" [unfinished], but don't have a suggestion for content.

thanks for writing and publishing interrupt!