### PR TITLE
Tiny changes on posts

### DIFF
--- a/_posts/2019-07-23-using-pypi-packages-with-GDB.md
+++ b/_posts/2019-07-23-using-pypi-packages-with-GDB.md
@@ -310,6 +310,7 @@ In my local `~/.gdbinit` script, I will place the following code snippet at the
 bottom.
 
 ```python
+python
 # Update GDB's Python paths with the `sys.path` values of the local
 #  Python installation, whether that is brew'ed Python, a virtualenv,
 #  or another system python.

--- a/_posts/2019-11-20-cortex-m-fault-debug.md
+++ b/_posts/2019-11-20-cortex-m-fault-debug.md
@@ -357,6 +357,7 @@ To use the utility, all you need to do is update your `.gdbinit` to use PyPi pac
 
 ```shell
 $ git clone git@github.com:bnahill/PyCortexMDebug.git
+# Check out Python 2 compatible code
 $ git checkout 77af54e
 $ cd PyCortexMDebug
 $ python setup.py install

--- a/_posts/2019-11-20-cortex-m-fault-debug.md
+++ b/_posts/2019-11-20-cortex-m-fault-debug.md
@@ -357,6 +357,7 @@ To use the utility, all you need to do is update your `.gdbinit` to use PyPi pac
 
 ```shell
 $ git clone git@github.com:bnahill/PyCortexMDebug.git
+$ git checkout 77af54e
 $ cd PyCortexMDebug
 $ python setup.py install
 ```


### PR DESCRIPTION
Hello interrupters!

Here are some changes that I find relevant to update during my readings. 

The first commit I guess is self explanatory. 

On the second one I would love to hear your thoughts on this. [PyCortexMDebug](https://github.com/bnahill/PyCortexMDebug ) has been pushing some code that don't allow to run it over python 2. This make that steps shown about this package at  https://interrupt.memfault.com/blog/cortex-m-fault-debug article won't work. 
Assuming that we are using python 2 coming coming from https://interrupt.memfault.com/blog/automate-debugging-with-gdb-python-api I guess may somehow let the embedded developer know that checking out from cortex-m-fault-debug master won't work. So, I added a new line to checkout to the latest commit that actually works.

I'm not aware if there is an `arm-none-eabi-gdb-py` equivalent for python 3 though, so I'm all eyes to receive feedback. 

Also, as these changes are so small I decided to make it as a single PR, let me know if you would like to have these topics split. 

