### PR TITLE
Improved pagination UX

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,6 +15,7 @@ destination: ./_site/blog
 markdown: kramdown
 permalink: /:title
 paginate: 8
+paginate_trail: 2
 paginate_path: /page:num/
 source: .
 excerpt_separator: "<!-- excerpt end -->"

--- a/_includes/pagination.html
+++ b/_includes/pagination.html
@@ -1,0 +1,42 @@
+{% if paginator.total_pages > 1 %}
+<div class="pagination d-none d-lg-block">
+    {% assign page_start = paginator.page | minus: site.paginate_trail %}
+    {% assign page_end = paginator.page | plus: site.paginate_trail %}
+
+    {% if paginator.previous_page == 1 %}
+        <a href="{{ '/' | prepend: site.baseurl | replace: '//', '/' }}" class="page-item" title="Previous page">&laquo;</a>
+    {% elsif paginator.previous_page %}
+        <a href="{{ paginator.previous_page_path | prepend: site.baseurl | replace: '//', '/' }}" class="page-item" title="Previous page">&laquo;</a>
+    {% else %}
+        <span class="page-item">&laquo;</span>
+    {% endif %}
+
+    {% if paginator.page != 1 and page_start > 1 %}
+        <a href="{{ '/' | prepend: site.baseurl | replace: '//', '/' }}" class="page-item" title="First page">1</a>
+        ...
+    {% endif %}
+
+    {% for page in (page_start..page_end) %}
+        {% if page < 1 or page > paginator.total_pages %}
+            <!-- Do nothing -->
+        {% elsif page == paginator.page %}
+            <span class="page-item">{{ page }}</span>
+        {% elsif page == 1 %}
+            <a href="{{ '/' | prepend: site.baseurl | replace: '//', '/' }}" class="page-item">{{ page }}</a>
+        {% else %}
+            <a href="{{ site.paginate_path | prepend: site.baseurl | replace: '//', '/' | replace: ':num', page }}" class="page-item">{{ page }}</a>
+        {% endif %}
+    {% endfor %}
+
+    {% if paginator.page != paginator.total_pages and page_end < paginator.total_pages %}
+        ...
+        <a href="{{ site.paginate_path | replace: ':num', paginator.total_pages | prepend: site.baseurl | replace: '//', '/' }}" class="page-item" title="Last page">{{ paginator.total_pages }}</a>
+    {% endif %}
+
+    {% if paginator.next_page %}
+        <a href="{{ paginator.next_page_path | prepend: site.baseurl | replace: '//', '/' }}" class="page-item" title="Next page">&raquo;</a>
+    {% else %}
+        <span class="page-item">&raquo;</span>
+    {% endif %}
+</div>
+{% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -27,31 +27,7 @@
 	  </main>
 		
 		  <!-- Pagination links -->
-      {% if paginator.total_pages > 1 %}
-        <div class="pagination">
-          {% if paginator.previous_page %}
-            <a href="{{ paginator.previous_page_path | relative_url }}" class="page-item">&laquo;</a>
-          {% else %}
-            <span class="page-item">&laquo;</span>
-          {% endif %}
-        
-          {% for page in (1..paginator.total_pages) %}
-            {% if page == paginator.page %}
-              <span class="page-item">{{ page }}</span>
-            {% elsif page == 1 %}
-              <a href="{{ '/' | relative_url }}" class="page-item">{{ page }}</a>
-            {% else %}
-              <a href="{{ site.paginate_path | replace: ':num', page | relative_url }}" class="page-item">{{ page }}</a>
-            {% endif %}
-          {% endfor %}
-        
-          {% if paginator.next_page %}
-            <a href="{{ paginator.next_page_path | relative_url }}" class="page-item">&raquo;</a>
-          {% else %}
-            <span class="page-item">&raquo;</span>
-          {% endif %}
-        </div>
-        {% endif %}
+      {% include pagination.html %}
 
 	  </div>
 	    

--- a/_layouts/split-view.html
+++ b/_layouts/split-view.html
@@ -33,31 +33,8 @@
       </div>
 
         <!-- Pagination links -->
-        {% if paginator.total_pages > 1 %}
-          <div class="pagination">
-            {% if paginator.previous_page %}
-              <a href="{{ paginator.previous_page_path | relative_url }}" class="page-item">&laquo;</a>
-            {% else %}
-              <span class="page-item">&laquo;</span>
-            {% endif %}
-
-            {% for page in (1..paginator.total_pages) %}
-              {% if page == paginator.page %}
-                <span class="page-item">{{ page }}</span>
-              {% elsif page == 1 %}
-                <a href="{{ '/' | relative_url }}" class="page-item">{{ page }}</a>
-              {% else %}
-                <a href="{{ site.paginate_path | replace: ':num', page | relative_url }}" class="page-item">{{ page }}</a>
-              {% endif %}
-            {% endfor %}
-
-            {% if paginator.next_page %}
-              <a href="{{ paginator.next_page_path | relative_url }}" class="page-item">&raquo;</a>
-            {% else %}
-              <span class="page-item">&raquo;</span>
-            {% endif %}
-          </div>
-          {% endif %}
+        {% include pagination.html %}
+        
     </div>
 
         <!-- Footer -->


### PR DESCRIPTION
Hello 👋

I noticed that the blog page count has been increasing. Because of that, the pagination is starting to look overwhelming. Not that it looks bad at it's current state, but as the page count increases it will become overpopulated with page number buttons.

_Current_
![current pagination](https://i.imgur.com/SFxj8ci.png)

---

I have found a better solution for pagination. 

I took the inspiration from the following sources:
* https://dribbble.com/shots/2351417-What-s-your-fav-pagination (example number 7)
* https://uxframework.pearson.com/c/pagination (Standard pagination)
* https://codemyui.com/pagination-ux-pure-css/

Here's how it works:

The structure is as follows:
`[Previous page] [First page number] ... (N trailing) [Current page] (N leading) ... [Last page number] [Next page]`

There is a new option in **_config.yml** file called `paginate_trail` and the dafault value is `2`. It is used to generate N (in default case 2) trailing and leading page buttons.

_First page_
![first page](https://i.imgur.com/UposL6o.png)

You can notice that there is no "First page" button, because page 1 button is already visible.

_Second page_
![second page](https://i.imgur.com/4pD7AiU.png)

Second page also does not have the "First page" button, for same reason as for page 1.

_Page N_
![page n](https://i.imgur.com/ll6sS69.png)

When we get to page N, we can see trailing and leading N buttons (default 2), first page button (1), last page (10) and next and previous buttons. This way, user can proceed in reading posts chronologically, but he has an option to go to first and last page, as well as a way for "faster navigation" if a user is searing for some post.

_Last page_
![last page](https://i.imgur.com/jPlGBee.png)

The "Last page" button will not be visible on last page. Simillar logic for the first page.

---

I hope all of this makes sense. You can clone my fork and try it out locally.
