### PR TITLE
[Webinar recording] few updates

### DIFF
--- a/_posts/2019-07-02-automate-debugging-with-gdb-python-api.md
+++ b/_posts/2019-07-02-automate-debugging-with-gdb-python-api.md
@@ -11,6 +11,8 @@ tags: [python, gdb]
 
 <!-- excerpt end -->
 
+> If you'd rather listen to me present this information and see some demos in action, [watch this webinar recording.](https://go.memfault.com/debugging-arm-cortex-m-mcu-webinar?utm_campaign=Debugging%20Cortex%20M%20Webinar&utm_source=blog&utm_medium=Interrupt&utm_term=Debug)
+
 When a system hits a failure state, you will often find yourself looking at similar state to determine how the system got into the failure mode. This may entail inspecting linked lists, heaps, OS primitives such as mutexes or queues, state of peripherals, etc
 
 Perhaps you are guilty of doing things like this to determine how much memory was burned up in a linked list:
@@ -392,5 +394,7 @@ Next time, we'll talk about how to use third-party Python packages within GDB us
 _EDIT: Post written!_ - [Using Python PyPi Packages with GDB]({% post_url 2019-07-23-using-pypi-packages-with-GDB %})
 
 _All the code used in this blog post is available on [Github](https://github.com/memfault/interrupt/tree/master/example/gdb-python-post/)._
+
+> Interested in learning more about debugging HardFaults? [Watch this webinar recording.](https://go.memfault.com/debugging-arm-cortex-m-mcu-webinar?utm_campaign=Debugging%20Cortex%20M%20Webinar&utm_source=blog&utm_medium=Interrupt&utm_term=Debug).
 
 {% include submit-pr.html %}

--- a/_posts/2019-07-16-fix-bugs-and-secure-firmware-with-the-mpu.md
+++ b/_posts/2019-07-16-fix-bugs-and-secure-firmware-with-the-mpu.md
@@ -18,6 +18,8 @@ In this article, we will deep dive into the unit and walk through a few practica
 
 <!-- excerpt end -->
 
+> If you'd rather listen to me present this information and see some demos in action, [watch this webinar recording.](https://go.memfault.com/debugging-arm-cortex-m-mcu-webinar?utm_campaign=Debugging%20Cortex%20M%20Webinar&utm_source=blog&utm_medium=Interrupt&utm_term=Debug)
+
 {% include newsletter.html %}
 
 {% include toc.html %}
@@ -387,5 +389,7 @@ You'll notice `MMARVALID` is _not_ set so `MMFAR` is not valid but bit 1 is set,
 We hope this post gave you a useful overview of how the _ARMv6-M_ & _ARMv7-M_ MPU works and can be leveraged to guard against software bugs and exploits. Future topics we'd like to delve into on the matter include the re-designed MPU present in the _ARMv8-M_ architecture and how to use the MPU for application sandboxing (running privileged and unprivileged code).
 
 Do you use the MPU on your products? Have you had a use case where you've leveraged some of the more interesting configuration options (i.e `SRD` region masking or more complex selection of `TEX`, `S`, `C`, `B` values for a _Cortex-M7_ with some caches)? Or do you have any questions about the material in the blog post or wish there were some other details we covered? Let us know in the discussion area below!
+
+> Interested in learning more about debugging HardFaults? [Watch this webinar recording.](https://go.memfault.com/debugging-arm-cortex-m-mcu-webinar?utm_campaign=Debugging%20Cortex%20M%20Webinar&utm_source=blog&utm_medium=Interrupt&utm_term=Debug).
 
 {% include submit-pr.html %}

--- a/_posts/2019-09-04-arm-cortex-m-exceptions-and-nvic.md
+++ b/_posts/2019-09-04-arm-cortex-m-exceptions-and-nvic.md
@@ -24,7 +24,7 @@ and a few examples written in C.
 Note: For the most part, the exception handling mechanism in all Cortex-M processors (ARMv6-M,
 ARMv7-M & ARMv8-M architectures) is the same. I will point out differences that do arise in the relevant sections below.
 
-> If you'd rather listen to me present this information and see some demos in action, [register for our webinar on April 22, 2021 here.](https://hubs.la/H0KCkl_0)
+> If you'd rather listen to me present this information and see some demos in action, [watch this webinar recording.](https://go.memfault.com/debugging-arm-cortex-m-mcu-webinar?utm_campaign=Debugging%20Cortex%20M%20Webinar&utm_source=blog&utm_medium=Interrupt&utm_term=Debug)
 
 {% include toc.html %}
 
@@ -735,7 +735,7 @@ topic but I've always found it hard to find a single place that aggregates the u
 Are there any other topics related to interrupts you'd like us to delve into? (No pun intended :D) Do you leverage any of
 ARMs fancy exception configuration features in your products? Let us know in the discussion area below!
 
-> Interested in learning more about debugging HardFaults? [Register for our webinar on April 22, 2021 here](https://hubs.la/H0KCkl_0).
+> Interested in learning more about debugging HardFaults? [Watch this webinar recording.](https://go.memfault.com/debugging-arm-cortex-m-mcu-webinar?utm_campaign=Debugging%20Cortex%20M%20Webinar&utm_source=blog&utm_medium=Interrupt&utm_term=Debug).
 
 {% include submit-pr.html %}
 

--- a/_posts/2019-10-30-cortex-m-rtos-context-switching.md
+++ b/_posts/2019-10-30-cortex-m-rtos-context-switching.md
@@ -22,7 +22,7 @@ porting an RTOS to a platform. We will also walk through a practical example of 
 **FreeRTOS** context switcher, `xPortPendSVHandler`, utilizing `gdb` to strengthen our understanding.
 
 <!-- excerpt end -->
-> If you'd rather listen to me present this information and see some demos in action, [register for our webinar on April 22, 2021 here.](https://hubs.la/H0KCkl_0)
+> If you'd rather listen to me present this information and see some demos in action, [watch this webinar recording.](https://go.memfault.com/debugging-arm-cortex-m-mcu-webinar?utm_campaign=Debugging%20Cortex%20M%20Webinar&utm_source=blog&utm_medium=Interrupt&utm_term=Debug)
 
 {% include newsletter.html %}
 
@@ -965,7 +965,7 @@ works.
 We'd love to hear interesting RTOS bugs you have tracked down or other topics you would like to see
 covered on the topic. Let me know in the discussion area below!
 
-> Interested in learning more about debugging HardFaults? [Register for our webinar on April 22, 2021 here](https://hubs.la/H0KCkl_0).
+> Interested in learning more about debugging HardFaults? [Watch this webinar recording.](https://go.memfault.com/debugging-arm-cortex-m-mcu-webinar?utm_campaign=Debugging%20Cortex%20M%20Webinar&utm_source=blog&utm_medium=Interrupt&utm_term=Debug).
 
 {% include submit-pr.html %}
 

--- a/_posts/2019-11-20-cortex-m-fault-debug.md
+++ b/_posts/2019-11-20-cortex-m-fault-debug.md
@@ -20,7 +20,7 @@ some faults without rebooting the MCU. We include practical examples, with a ste
 
 <!-- excerpt end -->
 
-> If you'd rather listen to me present this information and see some demos in action, [register for our webinar on April 22, 2021 here.](https://hubs.la/H0KCkl_0)
+> If you'd rather listen to me present this information and see some demos in action, [watch this webinar recording.](https://go.memfault.com/debugging-arm-cortex-m-mcu-webinar?utm_campaign=Debugging%20Cortex%20M%20Webinar&utm_source=blog&utm_medium=Interrupt&utm_term=Debug)
 
 {% include newsletter.html %}
 
@@ -1078,7 +1078,7 @@ I hope this post gave you a useful overview of how to debug a HardFault on a Cor
 Are there tricks you like to use that I didn't mention or other topics about faults you'd like to learn more about?
 Let us know in the discussion area below!
 
-> Interested in learning more about debugging HardFaults? [Register for our webinar on April 22, 2021 here](https://hubs.la/H0KCkl_0).
+> Interested in learning more about debugging HardFaults? [Watch this webinar recording.](https://go.memfault.com/debugging-arm-cortex-m-mcu-webinar?utm_campaign=Debugging%20Cortex%20M%20Webinar&utm_source=blog&utm_medium=Interrupt&utm_term=Debug).
 
 {% include submit-pr.html %}
 


### PR DESCRIPTION
Change the box text on each of the above pages to say:
If you'd rather listen to me present this information and see some demos in action, watch this webinar recording.

Interested in learning more about debugging HardFaults? watch this webinar recording.

Could you also add those same text boxes to these posts:
https://interrupt.memfault.com/blog/automate-debugging-with-gdb-python-api
https://interrupt.memfault.com/blog/fix-bugs-and-secure-firmware-with-the-mpu