### PR TITLE
post: example: mcuboot: freeze mcuboot to specific version

### DIFF
--- a/example/mcuboot/bootloader/Makefile
+++ b/example/mcuboot/bootloader/Makefile
@@ -132,6 +132,7 @@ $(OBJ_FILES): Makefile
 $(MCUBOOT_DIR):
 	mkdir -p $(EXTERNAL_DIR)
 	git clone --recurse-submodules=. https://github.com/mcu-tools/mcuboot.git $(EXTERNAL_DIR)/mcuboot
+	cd $(EXTERNAL_DIR)/mcuboot && git checkout e512181 && git submodule update --recursive
 
 $(SRC_FILES): $(MCUBOOT_DIR)
 


### PR DESCRIPTION
This commit sets mcu boot repository used in example to a state where
the porting code implemented here is able to compile. The reason why
doing this is that, mcu boot so far has introduced several changes
that are missing in example. This will allow to compile the code right
away.

