### PR TITLE
Prevent underflow by many backspaces in firmware-shell

### DIFF
--- a/example/firmware-shell/complex/shell/src/shell.c
+++ b/example/firmware-shell/complex/shell/src/shell.c
@@ -130,7 +130,9 @@ void shell_receive_char(char c) {
   prv_echo(c);
 
   if (c == '\b') {
-    s_shell.rx_buffer[--s_shell.rx_size] = '\0';
+    if (s_shell.rx_size > 0) {
+      s_shell.rx_buffer[--s_shell.rx_size] = '\0';
+    }
     return;
   }
 


### PR DESCRIPTION
Successive backspace can break `rx_buffer` by making `rx_size` nagetive. I added if statement to prevent this.