### PR TITLE
Fix typo in how-to-write-a-bootloader-from-scratch

### DIFF
--- a/_posts/2019-08-13-how-to-write-a-bootloader-from-scratch.md
+++ b/_posts/2019-08-13-how-to-write-a-bootloader-from-scratch.md
@@ -480,7 +480,7 @@ struct shared_data {
 };
 #pragma pack (pop)
 
-struct shared_data *sd = (struct shared_data *)_shared_data_stat;
+struct shared_data *sd = (struct shared_data *)&_shared_data_start;
 
 uint8_t shared_data_get_boot_count(void) {
   return sd->boot_count;

--- a/_posts/2021-11-23-noinit-memory.md
+++ b/_posts/2021-11-23-noinit-memory.md
@@ -198,6 +198,27 @@ be implemented and used
 
 ### No bootloader, just application
 
+(See [How to write a bootloader from scratch (The Interrupt): Message passing to
+catch reboot
+loops](https://interrupt.memfault.com/blog/how-to-write-a-bootloader-from-scratch#message-passing-to-catch-reboot-loops)
+for another example of this!)
+
+<!--
+Unfortunately, Jekyll's post_url tag can't handle Markdown anchors:
+
+https://jekyllrb.com/docs/liquid/tags/#link
+
+Otherwise we'd do something like this:
+
+{% raw %}
+{% post_url
+  2019-08-13-how-to-write-a-bootloader-from-scratch#message-passing-to-catch-reboot-loops
+  %}
+{% endraw %}
+
+C'est la vie.
+-->
+
 This system just has a single application that immediately starts when the chip
 is powered up. There's two variables located in the `.noinit` section:
 


### PR DESCRIPTION
Typo in the example on message passing, thanks @vpetrigo and @v-barshaw
for finding it!

Also update the noinit article with a reference to this example.

Fixes #171.
