### PR TITLE
Fix unbalanced parens in noinit example code

### DIFF
--- a/_posts/2021-11-23-noinit-memory.md
+++ b/_posts/2021-11-23-noinit-memory.md
@@ -132,7 +132,7 @@ To place a symbol into a `.noinit` region, see the following C code examples:
 
 ```c
 // For GCC or Clang or derived toolchains, use the "section" __attribute__ .
-__attribute__((section(".noinit")) volatile int my_non_initialized_integer;
+__attribute__((section(".noinit"))) volatile int my_non_initialized_integer;
 
 // for IAR EWARM, it varies, but typically:
 __no_init volatile int my_non_initialized_integer @ ".noinit";


### PR DESCRIPTION
```
main.c:15:35: error: expected ')' before 'volatile'
   15 | __attribute__((section(".noinit")) volatile int my_non_initialized_integer;
      |                                   ^~~~~~~~~
      |                                   )
```
```
$ arm-none-eabi-gcc --version
arm-none-eabi-gcc (GNU Arm Embedded Toolchain 10.3-2021.07) 10.3.1 20210621 (release)
```