### PR TITLE
Renode peripheral name changed from uart2 to usart2

### DIFF
--- a/example/renode/renode-config.resc
+++ b/example/renode/renode-config.resc
@@ -10,7 +10,7 @@ machine LoadPlatformDescription @platforms/boards/stm32f4_discovery-kit.repl
 machine LoadPlatformDescription @add-ccm.repl
 
 # Create a terminal window showing the output of UART2
-showAnalyzer sysbus.uart2
+showAnalyzer sysbus.usart2
 
 # Enable GDB
 machine StartGdbServer 3333

--- a/example/renode/tests/test-button.robot
+++ b/example/renode/tests/test-button.robot
@@ -11,7 +11,7 @@ Should Handle Button Press
     Execute Command         machine LoadPlatformDescription @${PATH}/add-ccm.repl
     Execute Command         sysbus LoadELF @${PATH}/renode-example.elf
 
-    Create Terminal Tester  sysbus.uart2
+    Create Terminal Tester  sysbus.usart2
 
     Start Emulation
 


### PR DESCRIPTION
Renode changed the name of the UART peripherals from `uartx` to `usartx`, which breaks the Renode example. This PR changes `uart2` to `usart2`.