### PR TITLE
USART2 RX not configured correctly in fwup example code

### DIFF
--- a/example/fwup-architecture/gpio.c
+++ b/example/fwup-architecture/gpio.c
@@ -4,7 +4,7 @@
 
 void gpio_setup(void)
 {
-	/* Setup GPIO pin GPIO12 on GPIO port D for LED. */
+    /* Setup GPIO pin GPIO12 on GPIO port D for LED. */
 	gpio_mode_setup(GPIOD, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, GPIO12);
 
 	/* Setup GPIO pins for USART2 transmit. */

--- a/example/fwup-architecture/gpio.c
+++ b/example/fwup-architecture/gpio.c
@@ -7,9 +7,14 @@ void gpio_setup(void)
     /* Setup GPIO pin GPIO12 on GPIO port D for LED. */
     gpio_mode_setup(GPIOD, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, GPIO12);
 
-    /* Setup GPIO pins for USART2 transmit. */
-    gpio_mode_setup(GPIOA, GPIO_MODE_AF, GPIO_PUPD_NONE, GPIO2);
+	/* Setup GPIO pins for USART2 transmit. */
+	gpio_mode_setup(GPIOA, GPIO_MODE_AF, GPIO_PUPD_NONE, GPIO2);
 
-    /* Setup USART2 TX pin as alternate function. */
-    gpio_set_af(GPIOA, GPIO_AF7, GPIO2);
+	/* Setup GPIO pins for USART2 receive. */
+	gpio_mode_setup(GPIOA, GPIO_MODE_AF, GPIO_PUPD_NONE, GPIO3);
+	gpio_set_output_options(GPIOA, GPIO_OTYPE_OD, GPIO_OSPEED_25MHZ, GPIO3);
+
+	/* Setup USART2 TX and RX pin as alternate function. */
+	gpio_set_af(GPIOA, GPIO_AF7, GPIO2);
+	gpio_set_af(GPIOA, GPIO_AF7, GPIO3);
 }

--- a/example/fwup-architecture/gpio.c
+++ b/example/fwup-architecture/gpio.c
@@ -4,8 +4,8 @@
 
 void gpio_setup(void)
 {
-    /* Setup GPIO pin GPIO12 on GPIO port D for LED. */
-    gpio_mode_setup(GPIOD, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, GPIO12);
+	/* Setup GPIO pin GPIO12 on GPIO port D for LED. */
+	gpio_mode_setup(GPIOD, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, GPIO12);
 
 	/* Setup GPIO pins for USART2 transmit. */
 	gpio_mode_setup(GPIOA, GPIO_MODE_AF, GPIO_PUPD_NONE, GPIO2);

--- a/example/fwup-architecture/gpio.c
+++ b/example/fwup-architecture/gpio.c
@@ -5,16 +5,16 @@
 void gpio_setup(void)
 {
     /* Setup GPIO pin GPIO12 on GPIO port D for LED. */
-	gpio_mode_setup(GPIOD, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, GPIO12);
+    gpio_mode_setup(GPIOD, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, GPIO12);
 
-	/* Setup GPIO pins for USART2 transmit. */
-	gpio_mode_setup(GPIOA, GPIO_MODE_AF, GPIO_PUPD_NONE, GPIO2);
+    /* Setup GPIO pins for USART2 transmit. */
+    gpio_mode_setup(GPIOA, GPIO_MODE_AF, GPIO_PUPD_NONE, GPIO2);
 
-	/* Setup GPIO pins for USART2 receive. */
-	gpio_mode_setup(GPIOA, GPIO_MODE_AF, GPIO_PUPD_NONE, GPIO3);
-	gpio_set_output_options(GPIOA, GPIO_OTYPE_OD, GPIO_OSPEED_25MHZ, GPIO3);
+    /* Setup GPIO pins for USART2 receive. */
+    gpio_mode_setup(GPIOA, GPIO_MODE_AF, GPIO_PUPD_NONE, GPIO3);
+    gpio_set_output_options(GPIOA, GPIO_OTYPE_OD, GPIO_OSPEED_25MHZ, GPIO3);
 
-	/* Setup USART2 TX and RX pin as alternate function. */
-	gpio_set_af(GPIOA, GPIO_AF7, GPIO2);
-	gpio_set_af(GPIOA, GPIO_AF7, GPIO3);
+    /* Setup USART2 TX and RX pin as alternate function. */
+    gpio_set_af(GPIOA, GPIO_AF7, GPIO2);
+    gpio_set_af(GPIOA, GPIO_AF7, GPIO3);
 }

--- a/example/fwup-architecture/usart.c
+++ b/example/fwup-architecture/usart.c
@@ -8,7 +8,7 @@ void usart_setup(void)
     usart_set_baudrate(USART2, 115200);
     usart_set_databits(USART2, 8);
     usart_set_stopbits(USART2, USART_STOPBITS_1);
-    usart_set_mode(USART2, USART_MODE_TX);
+    usart_set_mode(USART2, USART_MODE_TX_RX);
     usart_set_parity(USART2, USART_PARITY_NONE);
     usart_set_flow_control(USART2, USART_FLOWCONTROL_NONE);
 


### PR DESCRIPTION
I've been looking at fwup-architecture and fwup-signing examples. I know these example were tested with Renode but I've noticed that USART2 isn't setup correctly for receiving. 