### PR TITLE
Update docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,24 @@
-FROM ruby:2.7-alpine
+FROM ruby:3.0-slim-buster
 
-RUN apk --update add --no-cache --virtual build-dependencies build-base bash
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    python3 \
+    python3-pip
+
+# explicit and recent version of pip avoids needing to build wheel deps
+RUN pip3 install pip==22.3.1
 
 WORKDIR /memfault/interrupt
 
 COPY Gemfile .
 COPY Gemfile.lock .
-
 RUN bundle install
+
+COPY requirements.txt .
+RUN python3 -m pip install -r requirements.txt
+
+COPY entrypoint.sh ./entrypoint.sh
 
 EXPOSE 4000
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 set -euo pipefail
 
 bundle exec jekyll serve --host 0.0.0.0 -D

--- a/interrupt-server.sh
+++ b/interrupt-server.sh
@@ -1,2 +1,10 @@
-#!/bin/bash
-docker build -t interrupt . && docker run -it -v $(pwd):/memfault/interrupt:cached --rm -p 4000:4000 --rm interrupt
+#!/usr/bin/env bash
+
+# This script is used to run the interrupt site locally in a docker container.
+
+# Optionally, build a local image instead of pulling prebuilt
+if [ -n "${BUILD_DOCKER_IMAGE:-}" ]; then
+    docker build -t memfault/interrupt .
+fi
+
+docker run --rm -i -t --publish=4000:4000 --volume "${PWD}":/memfault/interrupt memfault/interrupt

--- a/readme.md
+++ b/readme.md
@@ -37,8 +37,9 @@ $ bundle exec jekyll serve --drafts --incremental --livereload
 
 Follow the instructions in the [Install Docker Engine](https://docs.docker.com/engine/install/) according to your operating system.
 
-Clone the repo, build and run:
-```
+Clone the repo, run in docker:
+
+```bash
 $ git clone https://github.com/memfault/interrupt.git
 $ cd interrupt
 $ ./interrupt-server.sh
@@ -48,7 +49,6 @@ $ ./interrupt-server.sh
 
 Interrupt is based on the Emerald theme by [Jacopo Rabolini](https://www.jacoporabolini.com/). Emerald is available on [Github](https://github.com/KingFelix/emerald).
 
-
-----
+---
 
 Interrupt is sponsored and edited by [Memfault](https://memfault.com).


### PR DESCRIPTION
Update to a more recent ruby version (2.7->3.0), which is necessary to
support the lunr.js jekyll plugin dep `therubyracer`.

Minor tweaks to the run script and image build, and push to docker hub.