### PR TITLE
Update lunr.js plugin to latest to use different libv8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'jekyll-seo-tag', "~> 2.7.1"
 
 group :jekyll_plugins do
   gem 'jekyll-diagrams'
-  gem 'jekyll-lunr-js-search'
+  gem 'jekyll-lunr-js-search', :git => 'https://github.com/memfault/jekyll-lunr-js-search.git', :ref => 'c872e3403dd8b885ef513910e4fd03ece7444da8'
 end
 
 gem "jekyll-target-blank", "~> 2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,13 @@
+GIT
+  remote: https://github.com/memfault/jekyll-lunr-js-search.git
+  revision: c872e3403dd8b885ef513910e4fd03ece7444da8
+  ref: c872e3403dd8b885ef513910e4fd03ece7444da8
+  specs:
+    jekyll-lunr-js-search (3.3.0)
+      execjs (~> 2.7)
+      json (~> 2.0)
+      nokogiri (~> 1.7)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -10,6 +20,7 @@ GEM
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
     eventmachine (1.2.7)
+    execjs (2.8.1)
     ffi (1.15.4)
     forwardable-extended (2.6.0)
     http_parser.rb (0.6.0)
@@ -37,10 +48,6 @@ GEM
     jekyll-get-json (1.0.0)
       deep_merge (~> 1.2)
       jekyll (>= 3.0)
-    jekyll-lunr-js-search (3.3.0)
-      json (~> 2.0)
-      nokogiri (~> 1.7)
-      therubyracer (~> 0.12)
     jekyll-paginate (1.1.0)
     jekyll-sass-converter (2.1.0)
       sassc (> 2.0.1, < 3.0)
@@ -56,7 +63,6 @@ GEM
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
-    libv8 (3.16.14.19)
     liquid (4.0.3)
     listen (3.7.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -73,7 +79,6 @@ GEM
     rb-fsevent (0.11.0)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    ref (2.0.0)
     rexml (3.2.5)
     rouge (3.26.1)
     safe_yaml (1.0.5)
@@ -81,9 +86,6 @@ GEM
       ffi (~> 1.9)
     terminal-table (2.0.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
-    therubyracer (0.12.3)
-      libv8 (~> 3.16.14.15)
-      ref
     unicode-display_width (1.8.0)
     webrick (1.7.0)
 
@@ -95,7 +97,7 @@ DEPENDENCIES
   jekyll-diagrams
   jekyll-feed (~> 0.15.1)
   jekyll-get-json (~> 1.0)
-  jekyll-lunr-js-search
+  jekyll-lunr-js-search!
   jekyll-paginate (~> 1.1)
   jekyll-seo-tag (~> 2.7.1)
   jekyll-target-blank (~> 2.0)

--- a/netlify.toml
+++ b/netlify.toml
@@ -6,4 +6,4 @@
 # Deploy Preview context: All Deploy Previews
 # will inherit these settings.
 [context.deploy-preview]
-  command = "jekyll build -D --future && cp _redirects _site/"
+  command = "jekyll build --trace -D --future && cp _redirects _site/"


### PR DESCRIPTION
This is updating the lunr.js plugin to do two things:

1. Use a libv8 library that works on Mac. This was already done in the
   'master' branch of the plugin, so we just update to the latest
   master.
2. Fix the large amount of JSON nesting by setting max_nesting to false.

---

Error:

```
Installing libv8 3.16.14.19 with native extensions
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /Users/tyler/dev/memfault/interrupt/vendor/bundle/ruby/2.7.0/gems/libv8-3.16.14.19/ext/libv8
/Users/tyler/.rbenv/versions/2.7.5/bin/ruby -I /Users/tyler/.rbenv/versions/2.7.5/lib/ruby/2.7.0 -r ./siteconf20230103-55676-1bomqs8.rb
extconf.rb
creating Makefile
/Users/tyler/dev/memfault/interrupt/vendor/bundle/ruby/2.7.0/gems/libv8-3.16.14.19/ext/libv8/builder.rb:86:in `setup_python!': libv8 requires
python 2 to be installed in order to build, but it is currently 3.8.12 (RuntimeError)
	from /Users/tyler/dev/memfault/interrupt/vendor/bundle/ruby/2.7.0/gems/libv8-3.16.14.19/ext/libv8/builder.rb:53:in `build_libv8!'
	from /Users/tyler/dev/memfault/interrupt/vendor/bundle/ruby/2.7.0/gems/libv8-3.16.14.19/ext/libv8/location.rb:24:in `install!'
	from extconf.rb:7:in `<main>'

extconf failed, exit code 1

Gem files will remain installed in /Users/tyler/dev/memfault/interrupt/vendor/bundle/ruby/2.7.0/gems/libv8-3.16.14.19 for inspection.
Results logged to /Users/tyler/dev/memfault/interrupt/vendor/bundle/ruby/2.7.0/extensions/x86_64-darwin-19/2.7.0/libv8-3.16.14.19/gem_make.out

  /Users/tyler/.rbenv/versions/2.7.5/lib/ruby/2.7.0/rubygems/ext/builder.rb:99:in `run'
  /Users/tyler/.rbenv/versions/2.7.5/lib/ruby/2.7.0/rubygems/ext/ext_conf_builder.rb:48:in `block in build'
  /Users/tyler/.rbenv/versions/2.7.5/lib/ruby/2.7.0/tempfile.rb:291:in `open'
  /Users/tyler/.rbenv/versions/2.7.5/lib/ruby/2.7.0/rubygems/ext/ext_conf_builder.rb:30:in `build'
  /Users/tyler/.rbenv/versions/2.7.5/lib/ruby/2.7.0/rubygems/ext/builder.rb:169:in `block in build_extension'
  /Users/tyler/.rbenv/versions/2.7.5/lib/ruby/2.7.0/rubygems/ext/builder.rb:165:in `synchronize'
  /Users/tyler/.rbenv/versions/2.7.5/lib/ruby/2.7.0/rubygems/ext/builder.rb:165:in `build_extension'
  /Users/tyler/.rbenv/versions/2.7.5/lib/ruby/2.7.0/rubygems/ext/builder.rb:210:in `block in build_extensions'
  /Users/tyler/.rbenv/versions/2.7.5/lib/ruby/2.7.0/rubygems/ext/builder.rb:207:in `each'
  /Users/tyler/.rbenv/versions/2.7.5/lib/ruby/2.7.0/rubygems/ext/builder.rb:207:in `build_extensions'
  /Users/tyler/.rbenv/versions/2.7.5/lib/ruby/2.7.0/rubygems/installer.rb:844:in `build_extensions'
  /Users/tyler/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/bundler-2.2.29/lib/bundler/rubygems_gem_installer.rb:66:in `build_extensions'
  /Users/tyler/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/bundler-2.2.29/lib/bundler/rubygems_gem_installer.rb:26:in `install'
  /Users/tyler/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/bundler-2.2.29/lib/bundler/source/rubygems.rb:199:in `install'
  /Users/tyler/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/bundler-2.2.29/lib/bundler/installer/gem_installer.rb:54:in `install'
  /Users/tyler/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/bundler-2.2.29/lib/bundler/installer/gem_installer.rb:16:in `install_from_spec'
  /Users/tyler/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/bundler-2.2.29/lib/bundler/installer/parallel_installer.rb:186:in `do_install'
/Users/tyler/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/bundler-2.2.29/lib/bundler/installer/parallel_installer.rb:177:in `block in
worker_pool'
  /Users/tyler/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/bundler-2.2.29/lib/bundler/worker.rb:62:in `apply_func'
  /Users/tyler/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/bundler-2.2.29/lib/bundler/worker.rb:57:in `block in process_queue'
  /Users/tyler/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/bundler-2.2.29/lib/bundler/worker.rb:54:in `loop'
  /Users/tyler/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/bundler-2.2.29/lib/bundler/worker.rb:54:in `process_queue'
  /Users/tyler/.rbenv/versions/2.7.5/lib/ruby/gems/2.7.0/gems/bundler-2.2.29/lib/bundler/worker.rb:91:in `block (2 levels) in create_threads'

An error occurred while installing libv8 (3.16.14.19), and Bundler cannot continue.

In Gemfile:
  jekyll-lunr-js-search was resolved to 3.3.0, which depends on
    therubyracer was resolved to 0.12.3, which depends on
      libv8
```