### PR TITLE
Make lunr.js index gen opt-in

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'jekyll-seo-tag', "~> 2.7.1"
 
 group :jekyll_plugins do
   gem 'jekyll-diagrams'
-  gem 'jekyll-lunr-js-search', :git => 'https://github.com/memfault/jekyll-lunr-js-search.git', :ref => 'c872e3403dd8b885ef513910e4fd03ece7444da8'
+  gem 'jekyll-lunr-js-search', :git => 'https://github.com/memfault/jekyll-lunr-js-search.git', :ref => '4db4cab461594a92022430fd75442747494f4160'
 end
 
 gem "jekyll-target-blank", "~> 2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/memfault/jekyll-lunr-js-search.git
-  revision: c872e3403dd8b885ef513910e4fd03ece7444da8
-  ref: c872e3403dd8b885ef513910e4fd03ece7444da8
+  revision: 4db4cab461594a92022430fd75442747494f4160
+  ref: 4db4cab461594a92022430fd75442747494f4160
   specs:
     jekyll-lunr-js-search (3.3.0)
       execjs (~> 2.7)

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,7 @@
 [build]
   command = "jekyll build && cp _redirects _site/"
   publish = "_site"
-
+  environment = { GENERATE_SEARCH_INDEX = "true" }
 
 # Deploy Preview context: All Deploy Previews
 # will inherit these settings.


### PR DESCRIPTION
It's super slow! so make it only run when the
`GENERATE_SEARCH_INDEX=true` environment variable is set.

See
https://github.com/memfault/jekyll-lunr-js-search/commit/4db4cab461594a92022430fd75442747494f4160
for the change that implements this in the lunr-js jekyll plugin fork.
