### PR TITLE
Fix annoying message when search index is missing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'jekyll-seo-tag', "~> 2.7.1"
 
 group :jekyll_plugins do
   gem 'jekyll-diagrams'
-  gem 'jekyll-lunr-js-search', :git => 'https://github.com/memfault/jekyll-lunr-js-search.git', :ref => '4db4cab461594a92022430fd75442747494f4160'
+  gem 'jekyll-lunr-js-search', :git => 'https://github.com/memfault/jekyll-lunr-js-search.git', :ref => '497e6c31849162d74872ec421017f364fd84b7c4'
 end
 
 gem "jekyll-target-blank", "~> 2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GIT
   remote: https://github.com/memfault/jekyll-lunr-js-search.git
-  revision: 4db4cab461594a92022430fd75442747494f4160
-  ref: 4db4cab461594a92022430fd75442747494f4160
+  revision: 497e6c31849162d74872ec421017f364fd84b7c4
+  ref: 497e6c31849162d74872ec421017f364fd84b7c4
   specs:
     jekyll-lunr-js-search (3.3.0)
       execjs (~> 2.7)

--- a/_includes/script.html
+++ b/_includes/script.html
@@ -4,8 +4,10 @@
 <script type="text/javascript" id="hs-script-loader" async defer src="//js.hs-scripts.com/8551838.js"></script>
 <!-- End of HubSpot Embed Code -->
 
+{% if jekyll.environment == "production" %}
 <!-- This is installed from the https://github.com/slashdotdash/jekyll-lunr-js-search Gem -->
 <script src="/js/search.min.js" type="text/javascript" charset="utf-8"></script>
+{% endif %}
 
 <script type="text/javascript">
     $(function() {

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,8 @@
 [build]
   command = "jekyll build && cp _redirects _site/"
   publish = "_site"
-  environment = { GENERATE_SEARCH_INDEX = "true" }
+  # this enables lunr.js search index generation
+  environment = { JEKYLL_ENV = "production" }
 
 # Deploy Preview context: All Deploy Previews
 # will inherit these settings.


### PR DESCRIPTION
In #315 I made the lunr.js search index generation opt-in via the
environment variable `GENERATE_SEARCH_INDEX`, but did not add a check
for the missing index file in that case, and that results in an error
when the page is loaded:

```
[2023-05-09 16:20:42] ERROR `/js/search.min.js' not found.
```

Update our forked plugin and the scripts template to omit the script for
non-production build; switch to the built-in environment variable
`JEKYLL_ENV` which is available to Liquid template expressions.