### PR TITLE
Amend README to remove the --incremental option when running locally

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,7 @@ $ git clone https://github.com/memfault/interrupt.git
 $ cd interrupt
 $ pip install -r requirements.txt
 $ bundle install
-$ bundle exec jekyll serve --drafts --incremental --livereload --open-url
+$ bundle exec jekyll serve --drafts --livereload --open-url
 ```
 
 ### Docker


### PR DESCRIPTION
This flag causes jekyll to not regenerate the page index which causes new posts to not show up in the blog list.

After further investigation, this behavior is known and documented: https://jekyllrb.com/docs/configuration/incremental-regeneration/