### PR TITLE
Create June 2023 Roundup

### DIFF
--- a/_posts/2023-07-05-june-2023-roundup.md
+++ b/_posts/2023-07-05-june-2023-roundup.md
@@ -1,0 +1,83 @@
+---
+title: "What we've been reading in June"
+author: tyler
+tags: [roundup]
+---
+
+<!-- excerpt start -->
+
+Here are the articles, videos, and tools that we've been excited about this
+June. 
+
+<!-- excerpt end -->
+
+We hope you enjoy these links, and we look forward to hearing what you've been
+reading in the comments or [on the Interrupt Slack](https://interrupt-slack.herokuapp.com/).
+
+
+## Articles & Learning
+- [**Memfault Panel - From Concept to Launch: What It Takes to Build and Ship a New Device (Recording)**](https://go.memfault.com/from-concept-launch-what-it-takes-build-ship-new-device?utm_campaign=Concept%20to%20Launch%20Panel&utm_source=Panelists)<br>
+I had a great time with Phillip Johnston ([Embedded Artistry](https://embeddedartistry.com/)) and Elecia White ([Embedded.fm](https://embedded.fm/) & [Logical Elegance](http://www.logicalelegance.com/site/)) discussing numerous things that we’ve learned about successful IoT product launches over our careers - often through trial and error. Check out the recording to hear our stories and tips. 
+
+- [**He started a computing REVOLUTION—then the shortage hit - YouTube**](https://www.youtube.com/watch?v=-_aL9V0JsQQ)<br>
+Jeff Geerling interviews Eben Upton, about the Raspberry Pi  shortages and the future. Great discussion! - Noah
+
+- [**AN25 - Switching Regulators for Poets: A Gentle Guide for the Trepidatious**](https://www.analog.com/media/en/technical-documentation/application-notes/an25fa.pdf)<br>
+More on the hardware side, but a classic app note from LTC - Noah
+
+- [**cuneicode, and the Future of Text in C | The Pasture**](https://thephd.dev/cuneicode-and-the-future-of-text-in-c)<br>
+Absolutely staggering article. Possibly the best thing I've read all year! - Noah
+
+- [**Generating Aligned Memory - Embedded Artistry**](https://embeddedartistry.com/blog/2017/02/22/generating-aligned-memory/)<br>
+From our good friend Phillip Johnston of [Embedded Artistry](https://embeddedartistry.com/), this article has been so helpful for some work I’m doing right now - Eric
+
+- [**Video-Based Cryptanalysis**](https://www.nassiben.com/video-based-crypta)<br>
+Side channel attack using power LED - Noah
+
+- [**Compiler Optimization of a Clamp Function | CoffeeBeforeArch.github.io**](https://coffeebeforearch.github.io/2020/08/12/clamp-optimization.html)<br>
+Fun walkthrough of compiler optimization/vectorization of a simple function - Noah
+
+- [**Valgrind Memcheck: Different ways to lose your memory | Red Hat Developer**](https://developers.redhat.com/blog/2021/04/23/valgrind-memcheck-different-ways-to-lose-your-memory#)<br>
+Nice article summarizing valgrind leak types - Noah
+
+- [**Innovation Handbook | DigiKey**](https://www.digikey.com/en/resources/innovation-handbook)<br>
+Collection of interesting reads from Digikey (some fundamentals, some more advanced topics) - Noah
+
+- [**Structures in C: From Basics to Memory Alignment – Abstract Expression**](https://abstractexpr.com/2023/06/29/structures-in-c-from-basics-to-memory-alignment/)<br>
+A nice overview of structs in C. The only thing it's missing in my opinion is a brief use-case of polymorphism in C using structs.
+
+- [**Memfault Webinar - An Introduction to Memfault's IoT Reliability Platform (Recording)**](https://go.memfault.com/introduction-to-memfault-iot-reliability-platform?utm_campaign=Memfault%20Overview&utm_source=Website&utm_medium=banner)<br>
+If you aren't already familiar with Memfault's product, Andie Cockerill (VP of Customer Experience) does a great job providing an overview and demo of our IoT reliability platform. 
+
+
+## Projects & Tools
+- [**wader/fq: jq for binary formats - tool, language and decoders for working with binary and text formats**](https://github.com/wader/fq)<br>
+A jq sibling "fq" that supports many binary formats including ELF - Fausto
+
+- [**hasheddan/dedock: not a container runtime.**](https://github.com/hasheddan/dedock)<br>
+Interesting project that intends to handle portable development environments on Linux and Macos - Noah
+
+- [**iDoka/awesome-embedded-software: :stars: List of software (HW interfaces, libs, protocols, etc) specifically suitable for resource-constrained Embedded Systems (low-memory and low-power) like 8-bit, 16-bit and 32-bit microcontrollers.**](https://github.com/iDoka/awesome-embedded-software)<br>
+Great list of links, shared on the Interrupt slack
+
+- [**floooh/sokol: minimal cross-platform standalone C headers**](https://github.com/floooh/sokol)<br>
+Nice set of headers for cross-platform apps - Noah
+
+- [**bristlemouth/bm_protocol**](https://github.com/bristlemouth/bm_protocol)<br>
+When I was at the SF Firmware Meetup a couple of weeks back, Alvaro Prieto gave me a preview of what Sofar Ocean is doing with [Bristlemouth](https://www.bristlemouth.org/) - an open standard/protocol for building hardware that sits in the middle of the ocean. My favorite part was definitely that they had to build their own cables since they were all too expensive or didn't work for long periods of time. Super cool stuff. 
+
+- [**Getting started with LPBAM - stm32mcu**](https://wiki.st.com/stm32mcu/wiki/Getting_started_with_LPBAM)<br>
+If you enjoy battery optimizations, the "low power batch autonomous mode" (LPBAM) peripheral mode for the MCU is quite neat - it lets you run DMA while the STM32 is in one of its lowest power states (stop mode) - Chris
+
+- [**cbiffle/lilos: A wee async RTOS for Cortex-M**](https://github.com/cbiffle/lilos)<br>
+Cliff Biffle published a Rust-based async RTOS called lilos. Cliff works at Oxide Computers, which published [Hubris](https://github.com/oxidecomputer/hubris), another Rust-based RTOS. Great to see so many Rust RTOS's coming out.
+
+- [**lupyuen/pinetime-rust-mynewt: PineTime Smart Watch firmware based on Rust and Apache Mynewt OS**](https://github.com/lupyuen/pinetime-rust-mynewt)<br>
+Application for the Pinetime smartwatch using Apache Mynewt + rust - Noah
+
+
+## Announcements & News
+- [**Announcing general availability of Zephyr 3.4 - Zephyr Project**](https://zephyrproject.org/announcing-general-availability-of-zephyr-3-4/)<br>
+Zephyr v3.4 is out! This blog post covers the latest changes and this very cool [video](https://www.youtube.com/watch?v=SbaW-YvbQTY) features new demos - Eric
+
+


### PR DESCRIPTION
- Noah's video on Raspberry Pi; in Articles & Learning, but should I create a "Random" section and add this there? Or would it make sense to add it to News & Announcements if it's an update on the shortage? 
- @bahildebrand saw your reply to my email about Mohammed's article. I'll add that next. Would this description work? "Memfault Ambassador Mohammed Billoo (MAB Labs) demystifies the “Kconfig” infrastructure that is an integral part of The Zephyr Project RTOS" -- borrowed directly from the newsletter
- Tyler's share on Bristlemouth; I think this is in the right spot (Projects & Tools) but LMK if I'm off
- Chris's share on the STM32U5 series; I left out the top line of what he shared on slack (https://theinterrupt.slack.com/archives/C01B3FET876/p1686936713910099). Does it make sense as I have it, or do I need to include "^ The devkit makes use of ST's STM32U5 series."? The way it was phrased/located made it a bit confusing. 