### PR TITLE
style: remove "welcome to" on landing page

### DIFF
--- a/_layouts/homepage.html
+++ b/_layouts/homepage.html
@@ -16,7 +16,7 @@
 
 		<div id="header">
 			<img id='logo' src="{% img_url interrupt-logo.svg %}" alt="Interrupt Logo">
-			<h1 class="header">Welcome to Interrupt!</h1>
+			<h1 class="header">Interrupt</h1>
 			<h3 class="header">by <a href="https://memfault.com">Memfault</a></h3>
 		</div>
 


### PR DESCRIPTION
The "Welcome to Memfault!" text on the landing page was deemed a bit
wordy, and suggested to be removed.