### PR TITLE
Add github action to check for redirects on rename

### DIFF
--- a/.github/workflows/detect-renamed-posts.js
+++ b/.github/workflows/detect-renamed-posts.js
@@ -1,0 +1,54 @@
+const fs = require("fs");
+const path = require("path");
+const child_process = require("child_process");
+
+const redirectsFilePath = path.join(
+  path.dirname(path.dirname(__dirname)),
+  "_redirects"
+);
+
+function updateRedirects(originalName, newName) {
+  const redirects = fs.readFileSync(redirectsFilePath, "utf-8");
+  const lines = redirects.split("\n");
+
+  const newRedirect = `/blog/${originalName} /blog/${newName}`;
+
+  // search for a line with newRedirect, if not found, raise an error
+  const found = lines.find((line) => line.trim() === newRedirect.trim());
+  if (found) {
+    console.log(`Yay, found redirect for ${originalName} -> ${newName}!`);
+  } else {
+    throw new Error(
+      `Could not find a redirect for /blog/${originalName} -> /blog/${newName}`
+    );
+  }
+}
+
+// Read the changed files list from git diff. Since this runs from a GitHub
+// Actions Pull Request environment, the delta from HEAD^ is _always_ exactly
+// what we care about, example:
+//   Checking out the ref
+//     /usr/bin/git checkout --progress --force refs/remotes/pull/362/merge
+//     Note: switching to 'refs/remotes/pull/362/merge'.
+//     ...
+//     HEAD is now at 3385152 Merge aee3dbdc3da6eba401ee67de178d100ca2a20431 into c9df39b302eac7c2f79d42541f14789f40584a61
+const gitCommand = `git diff --name-status --diff-filter=R -M5 HEAD^ -- _posts/`;
+const renamedFiles = child_process
+  .execSync(gitCommand)
+  .toString()
+  .split("\n")
+  .filter((file) => file !== "");
+renamedFiles.forEach((file) => {
+  // each line should have 3 elements:
+  // R100    _posts/2020-01-01-old-post.md    _posts/2020-01-01-new-post.md
+  const fileParts = file.split("\t");
+
+  // extract the original and new names
+  const [_, originalName, newName] = fileParts.map((filePart) =>
+    path
+      .basename(filePart, path.extname(filePart))
+      .replace(/^\d{4}-\d{2}-\d{2}-/, "")
+  );
+
+  updateRedirects(originalName, newName);
+});

--- a/.github/workflows/detect-renamed-posts.yml
+++ b/.github/workflows/detect-renamed-posts.yml
@@ -1,0 +1,28 @@
+name: Detect Renamed Posts
+
+on:
+
+  pull_request:
+    branches: [master]
+    paths:
+      - '_posts/**'
+
+jobs:
+  detect_renamed_post:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+        with:
+          # this enables doing git diff HEAD^ for the squashed PR commit
+          fetch-depth: 2
+
+      - name: Set Up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Run Renaming Script
+        run: |
+          node .github/workflows/detect-renamed-posts.js


### PR DESCRIPTION
See it catch the error here:

https://github.com/memfault/interrupt/actions/runs/5825914834/job/15798644392#step:4:9

See it pass when a redirect is included here:

https://github.com/memfault/interrupt/actions/runs/5826059210/job/15799126175#step:4:5