### PR TITLE
Force Pillow to stay at version 9.5.0 to prevent failing renders

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 blockdiag
+Pillow==9.5.0
 funcparserlib==1.0.0a0


### PR DESCRIPTION
 ### Summary
When reading through some old Interrupt articles, I noticed a bunch of block diagrams were not rendering.

For example, `blog/device-firmware-update-cookbook` would fail on multiple diagrams with messages like:
```
Rendering Failed: blockdiag -T svg --nodoctype /tmp/input20230824-6359-57l5w2 -o /tmp/output20230824-6359-1mps6hh.svg: ERROR: 'ImageDraw' object has no attribute 'textsize'
```

And the output in the terminal was failing with `   Jekyll Diagrams: Rendering Failed: blockdiag -T svg --nodoctype /var/folders/dz/5g4qmn_56lvcrd_mkswhf2w80000gn/T/input20230828-86743-6tj8l6 -o /var/folders/dz/5g4qmn_56lvcrd_mkswhf2w80000gn/T/output20230828-86743-uql6re.svg: ERROR: 'FreeTypeFont' object has no attribute 'getsize' `

I found this issue on `blockdiag`'s GitHub page, indicating that the package's dependency on Pillow needs to stay below 10.0.0: https://github.com/blockdiag/blockdiag/issues/178

This PR updates the `requirements.txt` file to force Pillow to stay at `9.5.0`, which renders the diagrams.

#### Before
<img width="300" alt="CleanShot 2023-08-28 at 21 16 54@2x" src="https://github.com/memfault/interrupt/assets/11810625/a971dc16-b529-458f-ab57-aeab8a783a1b">

#### After
<img width="300" alt="CleanShot 2023-08-28 at 21 21 43@2x" src="https://github.com/memfault/interrupt/assets/11810625/8cf8e941-fbcd-4538-a493-4d4ef658c306">
