### PR TITLE
Add more guidance on Ruby

### DIFF
--- a/.github/workflows/detect-ruby-version-mismatch.yml
+++ b/.github/workflows/detect-ruby-version-mismatch.yml
@@ -1,0 +1,18 @@
+name: Detect Ruby Version Mismatch
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - 'readme.md'
+      - '.ruby-version'
+
+jobs:
+  check_ruby_version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+      - name: Get version of Ruby
+        run: |
+          RUBY_VERSION=$(cat .ruby-version)
+          grep -- "- Ruby $RUBY_VERSION" readme.md

--- a/.github/workflows/detect-ruby-version-mismatch.yml
+++ b/.github/workflows/detect-ruby-version-mismatch.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3
-      - name: Get version of Ruby
+      - name: Verify Ruby version in readme.md matches .ruby-version
         run: |
           RUBY_VERSION=$(cat .ruby-version)
           grep -- "- Ruby $RUBY_VERSION" readme.md

--- a/.github/workflows/detect-ruby-version-mismatch.yml
+++ b/.github/workflows/detect-ruby-version-mismatch.yml
@@ -1,7 +1,8 @@
 name: Detect Ruby Version Mismatch
 on:
   workflow_dispatch:
-  push:
+  pull_request:
+    branches: [master]
     paths:
       - 'readme.md'
       - '.ruby-version'

--- a/readme.md
+++ b/readme.md
@@ -21,15 +21,43 @@ See [Contributing](https://interrupt.memfault.com/contributing) for more informa
 
 ### Locally
 
-Follow the instructions in the [Jekyll quickstart guide](https://jekyllrb.com/docs/) to install Ruby and Jekyll and bundler.
+You'll need:
+- Python 3.8 or later
+- Ruby 2.7.7
 
-Clone the repo, install dependencies, and serve:
+#### Install Dependencies
+
+Clone the repo and install Python dependencies:
 
 ```bash
 $ git clone https://github.com/memfault/interrupt.git
 $ cd interrupt
+# Setup a virtual environment to avoid cluttering your system
+$ python3 -m venv .venv
+# Activate the environment
+$ source .venv/bin/activate
 $ pip install -r requirements.txt
+```
+
+The virtual environment can be deactivated with `deactivate`.
+
+We highly recommend setting up a version manager for Ruby, such as
+`rbenv`. Follow the instructions [here](https://github.com/rbenv/rbenv) to set it
+up for your operating system and install the right version of Ruby.
+
+Install Ruby dependencies:
+
+```bash
+# Check that your Ruby version is correct
+$ ruby -v
 $ bundle install
+```
+
+#### Launch
+
+Serve with the following command, which will also open up the site in your browser:
+
+```bash
 $ bundle exec jekyll serve --drafts --livereload --open-url
 ```
 


### PR DESCRIPTION
Plus a GitHub workflow to make sure the `README` and `.ruby-version` are in sync 😎 

Can be tested by running the workflow manually:

```
gh workflow run detect-ruby-version-mismatch.yml --ref $(git rev-parse --abbrev-ref HEAD)
```

Tested by checking for failure when either the `README` or the `.ruby-version` was changed and there was a mismatch. Checked for success by reverting each change. Results are [here](https://github.com/memfault/interrupt/actions/workflows/detect-ruby-version-mismatch.yml).

Sadly didn't know re-named workflows generate a new workflow and [can't get removed](https://github.com/orgs/community/discussions/26256)...so there is an extra workflow in [Actions](https://github.com/memfault/interrupt/actions) from when I renamed the workflow that I've disabled for now.