### PR TITLE
Create July 2023 Roundup

### DIFF
--- a/_posts/2023-09-06-july-2023-roundup.md
+++ b/_posts/2023-09-06-july-2023-roundup.md
@@ -1,0 +1,73 @@
+---
+title: "What we've been reading in August"
+author: tyler
+tags: [roundup]
+---
+
+<!-- excerpt start -->
+
+Here are the articles, videos, and tools that we've been excited about this
+August. 
+
+<!-- excerpt end -->
+
+We hope you enjoy these links, and we look forward to hearing what you've been
+reading in the comments or [on the Interrupt Slack](https://interrupt-slack.herokuapp.com/).
+
+
+## Events
+- [**Memfault Webinar - IoT Device Security: Best Practices for Safeguarding Your Connected Devices**](https://hubs.la/Q0219KfY0)<br>
+Join Memfault's quarterly embedded panel on Thursday, September 7th with Phillip Johnston (Embedded Artistry), Tyler Hoffman (Memfault, and Benjamin "BamBam" Winston (Front), for an in-depth discussion on IoT Device Security. Our panelists will explore how to incorporate security into your product development process, what areas (like transport, actual data, keys) you should ensure are secure, how to lock down your hardware in relation to the sensitivity of the data, and much more. 
+
+- [**Memfault Webinar - Wrangling Penguins: Better Embedded Linux Monitoring and Debugging with Memfault**](https://hubs.la/Q0219Ks40)<br>
+Join this webinar on Thursday, September 14th with Memfault’s Linux Tech Lead Thomas Sarlandie to discover how Memfault enables you to collect and analyze device data to assist in monitoring, debugging, and updating Linux devices. 
+
+- [**Memfault Webinar - Boosting IoT Product Performance and Quality with Device Reliability Engineering**](https://app.livestorm.co/wkm/boosting-iot-product-performance-and-quality-with-device-reliability-engineering?utm_source=cl&utm_campaign=cl)<br>
+Join this IoT Now webinar on Thursday, September 28th with Memfault CEO & Interrupt Co-Creator, François Baldassari, and learn how utilizing device reliability engineering (DRE) techniques allows you to de-risk the product launches, positively impact customer satisfaction, and gain a competitive edge in the rapidly changing world of IoT.
+
+- [**Berlin Firmware Meetup by Memfault**](https://www.eventbrite.com/e/berlin-firmware-meetup-tickets-685436237237)<br>
+Team Memfault is hosting the first Berlin Firmware Meetup on Thursday, September 14th at [MotionLab.Berlin](https://motionlab.berlin/). This meetup offers a chance to learn about the latest embedded developments and to meet other like-minded engineers. Sign up [here](https://www.eventbrite.com/e/berlin-firmware-meetup-tickets-685436237237) for your free ticket.
+
+- [**San Francisco Firmware Meetup by Memfault**](https://www.eventbrite.com/e/sf-firmware-meetup-tickets-695013503097)<br>
+Team Memfault welcomes you to join us at the SF Firmware Meetup on Tuesday, September 19th for an evening of technical talks over food & drinks! Come hang out with team members from the San Francisco office and make new connections with local Bay Area embedded engineers. Get your free ticket [here](https://www.eventbrite.com/e/sf-firmware-meetup-tickets-695013503097). 
+
+- [**Boston Firmware Meetup by Memfault**](https://www.eventbrite.com/e/boston-firmware-meetup-tickets-678359811457)<br>
+Team Memfault would love to host you on Wednesday, September 20th at the next Boston Firmware Meetup. Mingle with members of the Boston office and connect with other local embedded engineers while listening to lightning talks and enjoying food and drink. Register [here](https://www.eventbrite.com/e/boston-firmware-meetup-tickets-678359811457) for your free ticket.
+
+
+## Articles & Learning
+- [**(4) Low Level Devel - Raspberry Pi Bare Metal - YouTube**](https://www.youtube.com/playlist?list=PLVxiWMqQvhg9FCteL7I0aohj1_YiUx1x8)<br>
+If you want to boot an ARM 64-bit A-class processor, bare-metal, assembly to C, check out this YouTube playlist recommended by Piyush Itankar. - Colleen
+
+- [**nRF Sniffer for Bluetooth LE - nRF52840 MDK USB Dongle**](https://wiki.makerdiary.com/nrf52840-mdk-usb-dongle/guides/ble-sniffer/)<br>
+A step-by-step guide on how to build a simple BLE sniffer using an nRF52840 DK and Wireshark. - François
+
+- [**Battery University Homepage**](https://batteryuniversity.com/)<br>
+A website devoted entirely to learning more about batteries. 
+
+- [**Enabling CodeChecker for your Zephyr RTOS Project - Benjamin Cabé**](https://blog.benjamin-cabe.com/2023/08/23/enabling-codechecker-for-your-zephyr-rtos-project)<br>
+Using codechecker with Zephyr, very cool. - Noah
+
+- [**Ports-and-Adapters Architecture: The Pattern – Burkhard Stubert**](https://embeddeduse.com/2023/08/24/ports-and-adapters-architecture-the-pattern/)<br>
+A good case for why ports-and-adapters (or hexagonal) architecture should be the standard for HMI applications.
+
+- [**VS Code: Virtual Environments for Embedded Development with Conda | MCU on Eclipse**](https://mcuoneclipse.com/2023/08/25/vs-code-virtual-environments-for-embedded-development-with-conda/)<br>
+Switch environments more easily and build your own packages during embedded development using Conda. 
+
+- [**Using nix-shell to create and share reproducible embedded development environments**](https://dnedic.github.io/blog/nix-shell-embedded-development-environment/)<br>
+More development environment management, this time using `nix-shell`. 
+
+
+## Projects & Tools
+- [**Drogue IoT**](https://www.drogue.io/)<br>
+An interesting IoT cloud project out of Red Hat that uses Rust and Embassy.
+
+- [**Introducing CMake Debugger in VS Code: Debug your CMake Scripts using Open-Source CMake Debugger - C++ Team Blog**](https://devblogs.microsoft.com/cppblog/introducing-cmake-debugger-in-vs-code-debug-your-cmake-scripts-using-open-source-cmake-debugger/)<br>
+Cmake Debugger is now available in VS Code, making it a strong reason to move to VS Code. 
+
+- [**OFRAK Tetris**](https://ofrak.com/tetris/)<br>
+Tetris, but the blocks are ARM instructions! Score is an integer at a particular address, the objective is to make it as high a value as possible. You can download your program as an elf at game over. - Noah
+
+- [**ataradov/usb-sniffer: Low-cost LS/FS/HS USB sniffer with Wireshark interface**](https://github.com/ataradov/usb-sniffer)<br>
+A very nice looking open source USB 2.0 packet sniffer. Found via [this nice writeup + video](https://www.downtowndougbrown.com/2023/08/building-alex-taradovs-open-source-usb-sniffer/) about building the sniffer. - Noah
+

--- a/_posts/2023-09-06-july-2023-roundup.md
+++ b/_posts/2023-09-06-july-2023-roundup.md
@@ -1,5 +1,5 @@
 ---
-title: "What we've been reading in August"
+title: "What we've been reading in August (2023)"
 author: tyler
 tags: [roundup]
 ---
@@ -15,27 +15,14 @@ We hope you enjoy these links, and we look forward to hearing what you've been
 reading in the comments or [on the Interrupt Slack](https://interrupt-slack.herokuapp.com/).
 
 
-## Events
+
+## Articles & Learning
 - [**Memfault Webinar - IoT Device Security: Best Practices for Safeguarding Your Connected Devices**](https://hubs.la/Q0219KfY0)<br>
 Join Memfault's quarterly embedded panel on Thursday, September 7th with Phillip Johnston (Embedded Artistry), Tyler Hoffman (Memfault, and Benjamin "BamBam" Winston (Front), for an in-depth discussion on IoT Device Security. Our panelists will explore how to incorporate security into your product development process, what areas (like transport, actual data, keys) you should ensure are secure, how to lock down your hardware in relation to the sensitivity of the data, and much more. 
 
 - [**Memfault Webinar - Wrangling Penguins: Better Embedded Linux Monitoring and Debugging with Memfault**](https://hubs.la/Q0219Ks40)<br>
 Join this webinar on Thursday, September 14th with Memfault’s Linux Tech Lead Thomas Sarlandie to discover how Memfault enables you to collect and analyze device data to assist in monitoring, debugging, and updating Linux devices. 
 
-- [**Memfault Webinar - Boosting IoT Product Performance and Quality with Device Reliability Engineering**](https://app.livestorm.co/wkm/boosting-iot-product-performance-and-quality-with-device-reliability-engineering?utm_source=cl&utm_campaign=cl)<br>
-Join this IoT Now webinar on Thursday, September 28th with Memfault CEO & Interrupt Co-Creator, François Baldassari, and learn how utilizing device reliability engineering (DRE) techniques allows you to de-risk the product launches, positively impact customer satisfaction, and gain a competitive edge in the rapidly changing world of IoT.
-
-- [**Berlin Firmware Meetup by Memfault**](https://www.eventbrite.com/e/berlin-firmware-meetup-tickets-685436237237)<br>
-Team Memfault is hosting the first Berlin Firmware Meetup on Thursday, September 14th at [MotionLab.Berlin](https://motionlab.berlin/). This meetup offers a chance to learn about the latest embedded developments and to meet other like-minded engineers. Sign up [here](https://www.eventbrite.com/e/berlin-firmware-meetup-tickets-685436237237) for your free ticket.
-
-- [**San Francisco Firmware Meetup by Memfault**](https://www.eventbrite.com/e/sf-firmware-meetup-tickets-695013503097)<br>
-Team Memfault welcomes you to join us at the SF Firmware Meetup on Tuesday, September 19th for an evening of technical talks over food & drinks! Come hang out with team members from the San Francisco office and make new connections with local Bay Area embedded engineers. Get your free ticket [here](https://www.eventbrite.com/e/sf-firmware-meetup-tickets-695013503097). 
-
-- [**Boston Firmware Meetup by Memfault**](https://www.eventbrite.com/e/boston-firmware-meetup-tickets-678359811457)<br>
-Team Memfault would love to host you on Wednesday, September 20th at the next Boston Firmware Meetup. Mingle with members of the Boston office and connect with other local embedded engineers while listening to lightning talks and enjoying food and drink. Register [here](https://www.eventbrite.com/e/boston-firmware-meetup-tickets-678359811457) for your free ticket.
-
-
-## Articles & Learning
 - [**(4) Low Level Devel - Raspberry Pi Bare Metal - YouTube**](https://www.youtube.com/playlist?list=PLVxiWMqQvhg9FCteL7I0aohj1_YiUx1x8)<br>
 If you want to boot an ARM 64-bit A-class processor, bare-metal, assembly to C, check out this YouTube playlist recommended by Piyush Itankar. - Colleen
 
@@ -57,6 +44,11 @@ Switch environments more easily and build your own packages during embedded deve
 - [**Using nix-shell to create and share reproducible embedded development environments**](https://dnedic.github.io/blog/nix-shell-embedded-development-environment/)<br>
 More development environment management, this time using `nix-shell`. 
 
+- [**Memfault Webinar - Boosting IoT Product Performance and Quality with Device Reliability Engineering**](https://app.livestorm.co/wkm/boosting-iot-product-performance-and-quality-with-device-reliability-engineering?utm_source=cl&utm_campaign=cl)<br>
+Join this IoT Now webinar on Thursday, September 28th with Memfault CEO & Interrupt Co-Creator, François Baldassari, and learn how utilizing device reliability engineering (DRE) techniques allows you to de-risk the product launches, positively impact customer satisfaction, and gain a competitive edge in the rapidly changing world of IoT.
+
+
+
 
 ## Projects & Tools
 - [**Drogue IoT**](https://www.drogue.io/)<br>
@@ -71,3 +63,15 @@ Tetris, but the blocks are ARM instructions! Score is an integer at a particular
 - [**ataradov/usb-sniffer: Low-cost LS/FS/HS USB sniffer with Wireshark interface**](https://github.com/ataradov/usb-sniffer)<br>
 A very nice looking open source USB 2.0 packet sniffer. Found via [this nice writeup + video](https://www.downtowndougbrown.com/2023/08/building-alex-taradovs-open-source-usb-sniffer/) about building the sniffer. - Noah
 
+
+
+## Community Events
+
+- [**Berlin Firmware Meetup by Memfault**](https://www.eventbrite.com/e/berlin-firmware-meetup-tickets-685436237237)<br>
+Team Memfault is hosting the first Berlin Firmware Meetup on Thursday, September 14th at [MotionLab.Berlin](https://motionlab.berlin/). This meetup offers a chance to learn about the latest embedded developments and to meet other like-minded engineers. Sign up [here](https://www.eventbrite.com/e/berlin-firmware-meetup-tickets-685436237237) for your free ticket.
+
+- [**San Francisco Firmware Meetup by Memfault**](https://www.eventbrite.com/e/sf-firmware-meetup-tickets-695013503097)<br>
+Team Memfault welcomes you to join us at the SF Firmware Meetup on Tuesday, September 19th for an evening of technical talks over food & drinks! Come hang out with team members from the San Francisco office and make new connections with local Bay Area embedded engineers. Get your free ticket [here](https://www.eventbrite.com/e/sf-firmware-meetup-tickets-695013503097). 
+
+- [**Boston Firmware Meetup by Memfault**](https://www.eventbrite.com/e/boston-firmware-meetup-tickets-678359811457)<br>
+Team Memfault would love to host you on Wednesday, September 20th at the next Boston Firmware Meetup. Mingle with members of the Boston office and connect with other local embedded engineers while listening to lightning talks and enjoying food and drink. Register [here](https://www.eventbrite.com/e/boston-firmware-meetup-tickets-678359811457) for your free ticket.


### PR DESCRIPTION
A few comments/questions:

- As always, can I please ask for a spot check to ensure I've divided up the URLs under the correct headings? 
- Noah and François both shared articles about packet sniffers and both mention Wireshark, but I *think* these are still two separate projects. Is that right? And I have François' share under "Articles & Learnings" but Noah's under "Projects & Tools". Should both be under "Projects & Tools"?
- I noticed after I committed that there is a "(4)" in the beginning of the YouTube link title, which needs to be removed (first share under "Articles & Learnings".
- I wrote a few of the descriptions for some of the links; if you think they could be more interesting or make a better point, then please feel free to change!

One more thing: all this year the title of each roundup has been "What we've been reading in [Month]". But looking at years prior, the year is included in the title in parenthesis. Should we start that for this month and go back and update the last few articles, or should this be done at the end of the year? Not sure how it was done in the past. 