### PR TITLE
fix: adjust submit PR banner

### DIFF
--- a/_includes/submit-pr.html
+++ b/_includes/submit-pr.html
@@ -1,3 +1,3 @@
 <div class="submit-pr">
-  <p class="submit-pr-content">See anything you'd like to change? Submit a pull request or open an issue at <a class="submit-pr-link" href="https://github.com/memfault/interrupt" target="_blank">GitHub</a></p>
+  <p class="submit-pr-content">See anything you'd like to change? Submit a pull request or open an issue on our <a class="submit-pr-link" href="https://github.com/memfault/interrupt" target="_blank">GitHub</a></p>
 </div>


### PR DESCRIPTION
### Summary

Adjust language to say "submit PR on our GitHub" instead of "at GitHub"