### PR TITLE
Isort version bump in pre-commit-config (fixes #456)

### DIFF
--- a/example/pre-commit/.pre-commit-config.yaml
+++ b/example/pre-commit/.pre-commit-config.yaml
@@ -46,7 +46,7 @@ repos:
       - id: black
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0 
     hooks:
       - id: isort
         args: [--profile=black]


### PR DESCRIPTION
Fixes https://github.com/memfault/interrupt/issues/456 as suggested also here: https://github.com/home-assistant/core/issues/86892#issuecomment-1407641288

By bumping `isort` version `5.10.1` to `5.12.0 ` 