### PR TITLE
banner: add notification for upcoming panel

### DIFF
--- a/_data/notifications.yml
+++ b/_data/notifications.yml
@@ -1,7 +1,5 @@
-# Notification Banner
-Benchmark Report:
+Notification Banner:
     background: '#141845'
     textcolor: '#fff'
-    title: Benchmark Report
     description: |
-        <i> New 2024 Benchmark Report on the State of IoT Software Development | <a href="https://hubs.la/Q02t-j2B0">See the Research</a></i>
+        <i> Upcoming Panel: IoT Experts Have Their Say on the State of IoT Software - Tuesday, May 7th, 2024 at 8AM PT | 11AM ET | 5PM CET | <a href="https://hubs.la/Q02w1lBQ0">RSVP</a></i>


### PR DESCRIPTION
### Summary

 We have a panel coming up on May 7th. This PR adds a notification to
 the site.

 Additionally removed the `title` field of the notification since
 it was not being used in the html `_includes/notifications.html` for
 rendering the banner.

 ### Test Plan

 Manually checked banner and link.