### PR TITLE
chore: remove panel notification banner

### DIFF
--- a/_data/notifications.yml
+++ b/_data/notifications.yml
@@ -1,5 +1,0 @@
-Notification Banner:
-    background: '#141845'
-    textcolor: '#fff'
-    description: |
-        <i> Upcoming Panel: IoT Experts Have Their Say on the State of IoT Software - Tuesday, May 7th, 2024 at 8AM PT | 11AM ET | 5PM CET | <a href="https://hubs.la/Q02w1lBQ0">RSVP</a></i>


### PR DESCRIPTION
### Summary

 Remove the banner advertising today's panel.

 ### Test Plan

 Verified banner is gone in preview