### PR TITLE
chore: replace launch week with IoT security panel banner

### DIFF
--- a/_data/notifications.yml
+++ b/_data/notifications.yml
@@ -2,4 +2,4 @@ Notification Banner:
   background: "#141845"
   textcolor: "#fff"
   description: |
-    <i> Memfault's Upcoming Launch Week - Product Analytics | June 24th - 28th <a href="https://memfault.com/launch-week/">Join us!</a></i>
+    <i> In-Person Denver Meetup: When to Build Security Into Your IoT Device - Thursday, July 18th @ 6pm MT. <a href="https://www.eventbrite.com/e/when-to-build-security-into-your-iot-device-tickets-911357283167">Save your spot!</a></i>


### PR DESCRIPTION
### Summary

Our IoT Security panel is coming up! This commit
replaces the old launch week banner with an invite
link to register for the security panel.

### Test Plan

Checked local render of banner + link works.