### PR TITLE
chore: add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,10 @@
+# See CODEOWNERS syntax documentation at:
+# https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
+#
+# Order is important; the last matching pattern takes the most precedence.
+
+##############################################################################
+# Generic owners - platform & codebase wide
+##############################################################################
+* @memfault/owners-interrupt
+


### PR DESCRIPTION
### Summary

 Currently just add a catch-all code owner for the whole repository so
 technical reviewers get notified when new PRs are opened.

 ### Test Plan

 Github auto-checks that the codeowners file is valid (see Files
 changed tab). The next PR to be opened with the latest as the base
branch will use the new CODEOWNERS file ([docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-and-forks)).