### PR TITLE
fix: adjust webiner CET time in banner

### DIFF
--- a/_data/notifications.yml
+++ b/_data/notifications.yml
@@ -2,4 +2,4 @@ Notification Banner:
     background: '#141845'
     textcolor: '#fff'
     description: |
-      <i> Webinar: How New IoT Security Regulations Will Shape the Industry's Future - Tuesday, Sept. 17th @ 9AM PT | 12PM ET | 7PM CET | <a href="https://hubs.la/Q02LvnFB0">RSVP Now</a> </i>
+      <i> Webinar: How New IoT Security Regulations Will Shape the Industry's Future - Tuesday, Sept. 17th @ 9AM PT | 12PM ET | 6PM CET | <a href="https://hubs.la/Q02LvnFB0">RSVP Now</a> </i>


### PR DESCRIPTION
### Summary

 The banner incorrectly says 7PM CET. Fix it to say 6PM CET

 ### Test Plan

 Visual check