### PR TITLE
publish: november 2024 roundup

### DIFF
--- a/_posts/2024-12-04-december-2024-roundup.md
+++ b/_posts/2024-12-04-december-2024-roundup.md
@@ -1,7 +1,8 @@
 ---
 title: "What we've been reading in December (2024)"
 description:
-  Here are the articles, videos, and tools we've been excited about in December 2024.
+  Here are the articles, videos, and tools we've been excited about in December
+  2024.
 author: gminn
 tags: [roundup]
 ---
@@ -19,52 +20,72 @@ What have you been reading? Share in the comments or
 ## Articles & Learning
 
 - [**Looking into the Nintendo Alarmo | Gary's hacking stuff**](https://garyodernichts.blogspot.com/2024/10/looking-into-nintendo-alarmo.html)<br>
-A fascinating walk-through on getting custom firmware running on the Nintendo Alarmo — a quirky alarm clock that wakes you up with sounds from your favorite Nintendo games. — Marc
+  A fascinating walk-through on getting custom firmware running on the Nintendo
+  Alarmo — a quirky alarm clock that wakes you up with sounds from your favorite
+  Nintendo games. — Marc
 
 - [**pahole: Analysing Memory Layout of Complex Data Structures With Ease | Performance Engineering**](https://pramodkumbhar.com/2023/11/pahole-to-analyz-data-structure-memory-layouts-with-ease/)<br>
-A nice walkthrough of using `pahole`!
+  A nice walkthrough of using `pahole`!
 
 - [**Good Comments Read Well and Are to the Point | Martin Tournoij**](https://www.arp242.net/comments.html)<br>
-A fantastic reminder to keep comments clear and succinct — even if it takes a few tries to distill the message.
+  A fantastic reminder to keep comments clear and succinct — even if it takes a
+  few tries to distill the message.
 
 - [**TLS/DTLS 1.3 Profiles for the Internet of Things | Datatracker**](https://datatracker.ietf.org/doc/draft-ietf-uta-tls13-iot-profile/)<br>
-Interesting RFC related to TLS 1.3 on embedded devices. — Noah
+  Interesting RFC related to TLS 1.3 on embedded devices. — Noah
 
 - [**An Introduction to Armv8-M Architecture in Cortex-M23 and Cortex-M33 | Hiroki Akaboshi, IAR**](https://www.iar.com/blog/an-introduction-to-armv8-m-architecture-in-cortex-m23-and-cortex-m33)<br>
-IAR published the first post of a short series on the Armv8-M architecture, which includes the Cortex-M23 and Cortex-M33 MCU's. This article covers MPU protection improvements and C11 support. — Tyler
+  IAR published the first post of a short series on the Armv8-M architecture,
+  which includes the Cortex-M23 and Cortex-M33 MCU's. This article covers MPU
+  protection improvements and C11 support. — Tyler
 
 - [**Exploring C++20 Coroutines for Embedded and Bare-metal Development on RISC-V platforms | Phil Mulholland**](https://philmulholland.medium.com/c-20-coroutines-re-entrant-scheduled-tasks-no-os-required-061c20efafad)<br>
-Can C++20 coroutines build efficient, real-time embedded applications on bare-metal RISC-V platforms — no RTOS required? This is something I've been playing around with for a while... — Phil M.
+  Can C++20 coroutines build efficient, real-time embedded applications on
+  bare-metal RISC-V platforms — no RTOS required? This is something I've been
+  playing around with for a while... — Phil M.
 
 - [**Lab Life Hack - Displaying Messages with SCPI | M0AGX / LB9MG**](https://m0agx.eu/lab-life-hack-display-annotate.html)<br>
-Don’t be afraid to experiment with your lab instruments! Learn how to build automated setups where multiple instruments work together seamlessly under one script.
+  Don’t be afraid to experiment with your lab instruments! Learn how to build
+  automated setups where multiple instruments work together seamlessly under one
+  script.
 
 - [**Why systemd is a Problem for Embedded Linux | Kevin Boone**](https://kevinboone.me/systemd_embedded.html)<br>
-This article is generating a lot of discussion on Hacker News. What's your take?
+  This article is generating a lot of discussion on Hacker News. What's your
+  take?
 
 - [**ESP32 bootstrapping in Zephyr | Espressif Developer Blog**](https://developer.espressif.com/blog/esp32-bootstrapping/)<br>
-Nice article by Espressif on the boot process for ESP32 + Zephyr — Noah
+  Nice article by Espressif on the boot process for ESP32 + Zephyr — Noah
 
 ## Projects & Tools
 
 - [**AES Encryption: Encrypt and Decrypt Online | cryptii**](https://cryptii.com/pipes/aes-encryption)<br>
-Stumbled across this while looking for online AES tools. It's pretty handy! — Andrew
+  Stumbled across this while looking for online AES tools. It's pretty handy! —
+  Andrew
 
-- [**CyberChef**](https://gchq.github.io/CyberChef/)<br>
-The Cyber Swiss Army Knife is a web app for encryption, encoding, compression, and data analysis. — Dave
+- [**CyberChef**](https://gchq.github.io/CyberChef/)<br> The Cyber Swiss Army
+  Knife is a web app for encryption, encoding, compression, and data analysis. —
+  Dave
 
 ## News & Announcements
 
 - [**Zephyr 4.0 is Generally Available | Zephyr Blog**](https://zephyrproject.org/zephyr-4-0-is-generally-available/)<br>
-Zephyr 4.0 was released on November 16th 🥳 We are especially excited to see all the [new boards](https://docs.zephyrproject.org/latest/releases/release-notes-4.0.html#boards-added-in-zephyr-4-0) (60 of them!) and the hard work done on new NXP and Espressif ESP32 chip support. — Noah
+  Zephyr 4.0 was released on November 16th 🥳 We are especially excited to see
+  all the
+  [new boards](https://docs.zephyrproject.org/latest/releases/release-notes-4.0.html#boards-added-in-zephyr-4-0)
+  (60 of them!) and the hard work done on new NXP and Espressif ESP32 chip
+  support. — Noah
 
 - [**Empowering Developers. Driving Innovation. Everywhere.**](https://blackberry.qnx.com/en/products/qnx-everywhere)<br>
-QNX is now free for non-commercial use. (Maybe too little, too late?) — François
+  QNX is now free for non-commercial use. (Maybe too little, too late?) —
+  François
 
 - [**FCC Authorizes Unlicensed Operations of 6 GHz Band**](https://broadbandbreakfast.com/fcc-authorizes-unlicensed-operations-of-6-ghz-band/)<br>
-Surprisingly, there's not much buzz about this. In March, the FCC greenlit seven new systems to manage spectrum in the 6 GHz band. Here's why it matters.
+  Surprisingly, there's not much buzz about this. In March, the FCC greenlit
+  seven new systems to manage spectrum in the 6 GHz band. Here's why it matters.
 
 ## Upcoming Events
 
 - [**January 7-10, 2025 | Las Vegas, NV | CES 202**](https://go.memfault.com/2025-ces)<br>
-Heading to CES 2025 next month? Meet up with Memfault and the Interrupt team in Exhibit Suite 29-223 (Venetian Tower). Schedule a demo to see how Memfault can help you build better IoT products, faster.
+  Heading to CES 2025 next month? Meet up with Memfault and the Interrupt team
+  in Exhibit Suite 29-223 (Venetian Tower). Schedule a demo to see how Memfault
+  can help you build better IoT products, faster.

--- a/_posts/2024-12-04-december-2024-roundup.md
+++ b/_posts/2024-12-04-december-2024-roundup.md
@@ -1,8 +1,7 @@
 ---
 title: "What we've been reading in December (2024)"
 description:
-  Here are the articles, videos, and tools we've been excited about in December
-  2024.
+  Here are the articles, videos, and tools we've been excited about in December 2024.
 author: gminn
 tags: [roundup]
 ---
@@ -23,10 +22,10 @@ What have you been reading? Share in the comments or
 A fascinating walk-through on getting custom firmware running on the Nintendo Alarmo — a quirky alarm clock that wakes you up with sounds from your favorite Nintendo games. — Marc
 
 - [**pahole: Analysing Memory Layout of Complex Data Structures With Ease | Performance Engineering**](https://pramodkumbhar.com/2023/11/pahole-to-analyz-data-structure-memory-layouts-with-ease/)<br>
-Until gdb's ptype has a pahole flag, try this! — Noah
+A nice walkthrough of using `pahole`!
 
 - [**Good Comments Read Well and Are to the Point | Martin Tournoij**](https://www.arp242.net/comments.html)<br>
-A fantastic reminder to keep comments clear and succinct — even if it takes a few tries to distill the message. 
+A fantastic reminder to keep comments clear and succinct — even if it takes a few tries to distill the message.
 
 - [**TLS/DTLS 1.3 Profiles for the Internet of Things | Datatracker**](https://datatracker.ietf.org/doc/draft-ietf-uta-tls13-iot-profile/)<br>
 Interesting RFC related to TLS 1.3 on embedded devices. — Noah
@@ -43,6 +42,9 @@ Don’t be afraid to experiment with your lab instruments! Learn how to build au
 - [**Why systemd is a Problem for Embedded Linux | Kevin Boone**](https://kevinboone.me/systemd_embedded.html)<br>
 This article is generating a lot of discussion on Hacker News. What's your take?
 
+- [**ESP32 bootstrapping in Zephyr | Espressif Developer Blog**](https://developer.espressif.com/blog/esp32-bootstrapping/)<br>
+Nice article by Espressif on the boot process for ESP32 + Zephyr — Noah
+
 ## Projects & Tools
 
 - [**AES Encryption: Encrypt and Decrypt Online | cryptii**](https://cryptii.com/pipes/aes-encryption)<br>
@@ -52,6 +54,9 @@ Stumbled across this while looking for online AES tools. It's pretty handy! — 
 The Cyber Swiss Army Knife is a web app for encryption, encoding, compression, and data analysis. — Dave
 
 ## News & Announcements
+
+- [**Zephyr 4.0 is Generally Available | Zephyr Blog**](https://zephyrproject.org/zephyr-4-0-is-generally-available/)<br>
+Zephyr 4.0 was released on November 16th 🥳 We are especially excited to see all the [new boards](https://docs.zephyrproject.org/latest/releases/release-notes-4.0.html#boards-added-in-zephyr-4-0) (60 of them!) and the hard work done on new NXP and Espressif ESP32 chip support. — Noah
 
 - [**Empowering Developers. Driving Innovation. Everywhere.**](https://blackberry.qnx.com/en/products/qnx-everywhere)<br>
 QNX is now free for non-commercial use. (Maybe too little, too late?) — François

--- a/_posts/2024-12-04-november-2024-roundup.md
+++ b/_posts/2024-12-04-november-2024-roundup.md
@@ -1,7 +1,7 @@
 ---
-title: "What we've been reading in December (2024)"
+title: "What we've been reading in November (2024)"
 description:
-  Here are the articles, videos, and tools we've been excited about in December
+  Here are the articles, videos, and tools we've been excited about in November
   2024.
 author: gminn
 tags: [roundup]
@@ -10,7 +10,7 @@ tags: [roundup]
 <!-- excerpt start -->
 
 Here are the articles, videos, and tools that we've been excited about this
-December.
+November.
 
 <!-- excerpt end -->
 


### PR DESCRIPTION
### Summary

 November 2024 roundup! A few tweaks from the draft:
 - December -> November (year is going by so fast, but not quite that fast!)
 - Add several new entries
 - Adjust `pahole` article comment

 ### Test Plan

 Link check, visual check