### PR TITLE
publish: merge december 2024 roundup with future publish date

### DIFF
--- a/_posts/2025-01-01-december-2024-roundup.md
+++ b/_posts/2025-01-01-december-2024-roundup.md
@@ -1,0 +1,70 @@
+---
+title: "What we've been reading in December (2024)"
+description:
+  Here are the articles, videos, and tools we've been excited about in December
+  2024.
+author: gminn
+tags: [roundup]
+---
+
+<!-- excerpt start -->
+
+🎆 Happy New Year! 🎆 Here's to making 2025 the best year yet. 2024 was an
+exciting year for Interrupt with 39 new articles, 6 new external contributors,
+and 576 new subscribers. Thanks for being a part of it!
+
+Here are the articles, videos, and tools that we've been excited about this
+December.
+
+<!-- excerpt end -->
+
+What have you been reading? Share in the comments or
+[on the Interrupt Slack](https://interrupt-slack.herokuapp.com/).
+
+## Articles & Learning
+
+- [**Controlling RGB LEDs With Only the Powerlines: Anatomy of a Christmas Light String | Tim's Blog**](https://cpldcpu.com/2022/01/23/controlling-rgb-leds-with-only-the-powerlines-anatomy-of-a-christmas-light-string/)<br>
+  Powerline control of RGB string lights. － Noah
+
+- [**X-macros: Not all C macros are evil | M0AGX / LB9MG**](https://m0agx.eu/not-all-c-macros-are-evil.html)<br>
+  Macros can be extremely useful for simplifying tasks like struct definitions.
+
+## Projects & Tools
+
+- [**pigg － Raspberry Pi GPIO GUI | GitHub**](https://github.com/andrewdavidmackenzie/pigg)<br>
+  Nice GUI-based tool for accessing Raspberry Pi GPIO pins (including the
+  Raspberry Pi Pico 2 W!) － Noah
+
+- [**Moonshine | GitHub**](https://github.com/usefulsensors/moonshine)<br> A
+  cool speech-to-text model optimized for (non-MCU) devices － François
+
+- [**Marimapper | GitHub**](https://github.com/TheMariday/marimapper)<br>
+  Video-based addressable LED mapping utility － Noah
+
+- [**Imposter Attack | Ian Langworth's Things of Variable Interest Blog**](https://blog.langworth.com/imposter-attack)<br>
+  Ian makes an Among Us themed game with an infrared gun, a bunch of ESP32s, and
+  LED lights. Looks really fun! － Tyler
+
+- [**Advent of Code on the Nintendo DS | sailor.li Blog**](https://sailor.li/aocnds.html)
+  Bootstrapping rust on the Nintendo DS, for solving Advent of Code
+  puzzles － Noah
+
+- [**ch32v003 USB Driver for 3-digit 7-segment TN LCDs | GitHub**](https://github.com/cnlohr/ch32v003_3digit_lcd_usb/)<br>
+  A neat project using one of the low-cost CV32 chips. The PCB cutout design for
+  the USB C connector is very nice! － Noah
+
+## News & Announcements
+
+- [**Introducing LVGL's UI Editor (Preview of v0.1) | LVGL YouTube**](https://www.youtube.com/watch?v=ntAuLhuK3Ck)<br>
+  The LVGL team recorded a walkthrough of their upcoming UI editor. I like how
+  beyond the editor itself, they embrace modern workflows such as “designers
+  live in Figma”, “reload UI without flashing new firmware” and even “generate
+  an interactive gallery of all composable UI elements in CI for stakeholders to
+  review early” － Heiko
+
+## Upcoming Events
+
+- [**January 7-10, 2025 | Las Vegas, NV | CES 202**](https://go.memfault.com/2025-ces)<br>
+  Heading to CES 2025 next month? Meet up with Memfault and the Interrupt team
+  in Exhibit Suite 29-223 (Venetian Tower). Schedule a demo to see how Memfault
+  can help you build better IoT products, faster.

--- a/readme.md
+++ b/readme.md
@@ -73,7 +73,7 @@ $ bundle install
 Serve with the following command, which will also open up the site in your browser:
 
 ```bash
-$ bundle exec jekyll serve --drafts --livereload --open-url
+$ bundle exec jekyll serve --drafts --livereload --open-url --future
 ```
 
 ## Acknowledgements


### PR DESCRIPTION
### Summary

 Happy New Year Interrupt 🎉 This post is scheduled for publish on 01/01.

 Additionally, I added the `--future` flag to the README to show how to view future posts locally (already added to the preview deployment).

 ### Test Plan

 - [x] Confirmed post is marked with the correct (future) date
 - [x] Check links