### PR TITLE
feat: add deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,22 @@
+name: Site Deployment
+
+on:
+  schedule:
+    # At 2:00pm UTC (10:00am ET) on Monday through Friday
+    # https://cron.help/#0_14_*_*_1-5
+    - cron: "0 14 * * 1-5"
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+    run_name:
+      description: "Name of the run, used to distinguish it from others"
+      required: false
+      type: string
+      default: ""
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy hook request
+        run: curl -X POST ${{ secrets.CLOUDFLARE_DEPLOY_HOOK }}


### PR DESCRIPTION
### Summary

 Currently, we only deploy the site on pushes to `master`. This works fine expect in the cases
 where we might was to schedule a post with a future publish date. This is scheduled for 10am ET every weekday.

 ### Test Plan

 - Manually triggered the workflow with
   `gh workflow run deploy.yml --ref gminn/add-daily-deployment`,
   confirmed it ran successfully ([result](https://github.com/memfault/interrupt/actions/runs/12739793493))
 - Confirmed site was deployed properly 🎉

    ![CleanShot 2025-01-12 at 21 58 41@2x](https://github.com/user-attachments/assets/9b045500-0853-4bf1-9a18-5404ac1a5d98)
