### PR TITLE
chore: remove time and date for esp32 interrupt live

### DIFF
--- a/_posts/2025-02-20-why-sleep-for-is-broken-on-esp32.md
+++ b/_posts/2025-02-20-why-sleep-for-is-broken-on-esp32.md
@@ -20,8 +20,7 @@ performance, but only in the new version of IDF due to an interaction between
 
 > 🎬
 > [Listen to Steve on Interrupt Live](https://youtube.com/live/dwL-PI7TuDY?feature=share)
-> at **9AM PT | 12PM ET | 6PM CET on Friday, March 7th** talk about the content
-> and motivations behind writing this article.
+> talk about the content and motivations behind writing this article.
 
 {% include newsletter.html %}
 


### PR DESCRIPTION
### Summary

 Interrupt live is now past, remove date and time in callout.

 ### Test Plan

 - [x] Visual check