### PR TITLE
chore: add latest Interrupt Live links

### DIFF
--- a/_posts/2024-01-10-practical_zephyr_basics.md
+++ b/_posts/2024-01-10-practical_zephyr_basics.md
@@ -29,6 +29,10 @@ After this series, you should understand Zephyr's build and configuration tools.
 
 > **Note:** This series is **not** for you if you're not interested in details and how things work but instead want to _use_ Zephyr. We'll go through _generated code and configuration files and learn _devicetree_ from first principles! Also, if you're experienced with Linux and already know how _Kconfig_ and _devicetree_ work, the articles of this series are just not for you.
 
+> 🎬
+> [Listen to Martin on Interrupt Live](https://www.youtube.com/watch?v=ls_Y45WsTiA?feature=share)
+> talk about the content and motivations behind writing this article.
+
 {% include newsletter.html %}
 
 {% include toc.html %}

--- a/_posts/2024-01-24-practical_zephyr_kconfig.md
+++ b/_posts/2024-01-24-practical_zephyr_kconfig.md
@@ -13,6 +13,10 @@ In this second article of the "Practical Zephyr" series, we'll explore the [kern
 
 👉 Find the other parts of the *Practical Zephyr* series [here](/tags#practical-zephyr-series).
 
+> 🎬
+> [Listen to Martin on Interrupt Live](https://www.youtube.com/watch?v=ls_Y45WsTiA?feature=share)
+> talk about the content and motivations behind writing this series.
+
 {% include newsletter.html %}
 
 {% include toc.html %}

--- a/_posts/2024-02-01-practical_zephyr_dt.md
+++ b/_posts/2024-02-01-practical_zephyr_dt.md
@@ -20,6 +20,10 @@ In contrast to _Kconfig_, the *Devicetree* syntax and its use are more intricate
 
 > **Disclaimer:** This article covers Devicetree in _detail_ and from first principles. If you're already familiar with Devicetree or don't want to know how it works in detail, this article may not be for you. Instead, consider tuning in for the next article!
 
+> 🎬
+> [Listen to Martin on Interrupt Live](https://www.youtube.com/watch?v=ls_Y45WsTiA?feature=share)
+> talk about the content and motivations behind writing this series.
+
 {% include newsletter.html %}
 
 {% include toc.html %}

--- a/_posts/2024-02-15-practical_zephyr_dt_semantics.md
+++ b/_posts/2024-02-15-practical_zephyr_dt_semantics.md
@@ -15,6 +15,10 @@ Having covered the *Devicetree basics* in the [previous article]({% post_url 202
 
 Notice that we'll only look at Zephyr's _basic_ Devicetree API and won't analyze specific subsystems such as `gpio` in detail. We're saving this for a practice round in the next article of this _Practical Zephyr_ series.
 
+> 🎬
+> [Listen to Martin on Interrupt Live](https://www.youtube.com/watch?v=ls_Y45WsTiA?feature=share)
+> talk about the content and motivations behind writing this series.
+
 {% include newsletter.html %}
 
 {% include toc.html %}

--- a/_posts/2024-04-17-practical_zephyr_05_dt_practice.md
+++ b/_posts/2024-04-17-practical_zephyr_05_dt_practice.md
@@ -15,6 +15,10 @@ Using a practical example, we'll see that our deep dive into Devicetree was real
 
 👉 Find the other parts of the *Practical Zephyr* series [here](/tags#practical-zephyr-series).
 
+> 🎬
+> [Listen to Martin on Interrupt Live](https://www.youtube.com/watch?v=ls_Y45WsTiA?feature=share)
+> talk about the content and motivations behind writing this series.
+
 {% include newsletter.html %}
 
 {% include toc.html %}

--- a/_posts/2024-05-16-practical_zephyr_west.md
+++ b/_posts/2024-05-16-practical_zephyr_west.md
@@ -15,6 +15,10 @@ After this article, you should know _West_ not as a meta-tool for `build` and `f
 
 👉 Find the other parts of the *Practical Zephyr* series [here](/tags#practical-zephyr-series).
 
+> 🎬
+> [Listen to Martin on Interrupt Live](https://www.youtube.com/watch?v=ls_Y45WsTiA?feature=share)
+> talk about the content and motivations behind writing this series.
+
 {% include newsletter.html %}
 
 {% include toc.html %}

--- a/_posts/2025-03-20-robust-ota-updates-the-easy-way.md
+++ b/_posts/2025-03-20-robust-ota-updates-the-easy-way.md
@@ -27,7 +27,7 @@ to complete, so let’s get started.
 <!-- excerpt end -->
 
 > 🎬
-> [Listen to Maximilian on Interrupt Live](https://www.youtube.com/watch?v=S2t2iAYmfuE?feature=share)
+> [Listen to Maximilian on Interrupt Live](https://www.youtube.com/watch?v=TlqWnUiUYmY?feature=share)
 > talk about the content and motivations behind writing this article.
 
 {% include newsletter.html %}


### PR DESCRIPTION
### Summary

 The latest Interrupt Live links have been added to the following posts:
  - [Practical Zephyr Basics](https://interrupt.memfault.com/blog/practical-zephyr-basics)
  - [Practical Zephyr Kconfig](https://interrupt.memfault.com/blog/practical-zephyr-kconfig)
  - [Practical Zephyr Device Tree](https://interrupt.memfault.com/blog/practical-zephyr-device-tree)
  - [Practical Zephyr Device Tree Semantics](https://interrupt.memfault.com/blog/practical-zephyr-device-tree-semantics)
  - [Practical Zephyr Device Tree Practice](https://interrupt.memfault.com/blog/practical-zephyr-device-tree-practice)
  - [Practical Zephyr West](https://interrupt.memfault.com/blog/practical-zephyr-west)
  - [Robust OTA Updates the Easy Way](https://interrupt.memfault.com/blog/robust-ota-updates-the-easy-way)