### PR TITLE
publish: linux coredumps part 3

### DIFF
--- a/_posts/2025-06-20-linux-coredumps-part-3.md
+++ b/_posts/2025-06-20-linux-coredumps-part-3.md
@@ -232,7 +232,7 @@ is an acronym for Common Information Entry and represents a shared set of
 instructions that can be used by any `FDE` in a given `CFI`. Let's take a gander
 at the `CIE` in our above example.
 
-#### Common Information (CIE) Record
+#### Common Information (`CIE`) Record
 
 ```bash
 00000000 0000000000000014 00000000 CIE
@@ -264,7 +264,7 @@ It is similar to the `CIE` but more specific in that it represents all
 instructions needed to recreate a frame's structure. Let's comb through an `FDE`
 to get a better understanding.
 
-#### Frame Description Entry (FDE) Record
+#### Frame Description Entry (`FDE`) Record
 
 ```bash
 00000018 0000000000000014 0000001c FDE cie=00000000 pc=00000000001c1180..00000000001c11a6
@@ -307,7 +307,7 @@ stack frame! Artisanal! Compiler to table! Let's decode the next line in our
 DW_CFA_offset: r16 (rip) at cfa-8
 ```
 
-Here we can see that `rip` (x86-64 program counter) can be computed by
+Here we can see that `rip` (`x86-64` program counter) can be computed by
 subtracting 8 from our previously calculated `CFA`. A visual representation of
 this can be seen below:
 

--- a/_posts/2025-06-20-linux-coredumps-part-3.md
+++ b/_posts/2025-06-20-linux-coredumps-part-3.md
@@ -140,7 +140,7 @@ our end goal, how do we get all of this from a Linux core handler?
 
 ## Understanding GNU Unwind Info
 
-To answer the above question, we need to look at how programs like GDB and perf
+To answer the above question, we need to look at how programs like GDB and `perf`
 traverse the stack. The first thing to note is that there are actually two parts
 to backtrace creation. Obviously, we need to convert raw addresses to function
 names and local variable names, but we also need to know how each frame is

--- a/_posts/2025-06-20-linux-coredumps-part-3.md
+++ b/_posts/2025-06-20-linux-coredumps-part-3.md
@@ -1,29 +1,35 @@
 ---
-title: Linux Coredumps (Part 3) - On Device Unwinding
-description: "Unwinding coredumps on device using `.eh_frame` and `addr2line`."
+title: Linux Coredumps (Part 3) － On Device Unwinding
+description: "Unwinding coredumps on-device using `.eh_frame` and `addr2line`."
 author: blake
 tags: [linux, coredumps, memfault, debugging]
 ---
 
-In our previous posts we covered how Linux coredumps are structured, how they're
-collected, and how we could reduce the size of them to fit on systems with less
-memory.
+In our previous posts, we covered how Linux coredumps are structured, how
+they're collected, and how we could reduce the size of them to fit on systems
+with less memory.
 
 <!-- excerpt start -->
 
-In this post we'll go over a method of coredump collection that does the stack
-unwinding on device. This allows devices that may be sensitive to leaking PII
-(Personally Identifiable Information) that may be stored in memory on the stack
-or heap to safely collect coredumps in addition to greatly reducing the size
-needed to store them.
+In this post, we'll go over a method of coredump collection that does the stack
+unwinding on-device. This approach allows devices that may be sensitive to
+leaking PII (Personally Identifiable Information) that may be stored in memory
+on the stack or heap to safely collect coredumps in addition to greatly reducing
+the size needed to store them.
 
 <!-- excerpt end -->
 
 By unwinding the stack locally on the device, we don't need to push any sections
-of memory out to another device/server, and can just push the PC of each frame
-to be symbolicated separately. In this post we'll cover the mechanism by which
+of memory out to another device/server and can just push the PC of each frame to
+be symbolicated separately. In this post, we'll cover the mechanism by which
 programs compiled with GCC/LLVM handle stack unwinding, and how we can leverage
 that to do local stack unwinding.
+
+> 📢 If you're attending Open Source Summit North America 2025, don’t miss
+> Blake's talk,
+> ["Efficient On-Device Core Dump Processing for IoT: A Rusty Implementation,"](https://sched.co/1zfib)
+> on Tuesday, June 24th at 9:00am MDT in Bluebird Ballroom 2B. He’ll dive even
+> deeper into the techniques explored in this series.
 
 {% include newsletter.html %}
 
@@ -37,31 +43,31 @@ captured memory. This achieves two goals:
 
 1. No risk of sensitive customer data leaving the device. If we're not capturing
    memory, it can't leave the device.
-2. A large reduction in size. Most of a coredump is comprised of large swaths of
-   captured raw memory.
+2. A significant reduction in size. Most of a coredump is comprised of large
+   swaths of captured raw memory.
 
-So what information do we need to capture? If we're not saving locals or any
-heap memory, at a minimum all we need is the `PC`(program counter) at each
-frame. This is just a raw address though. If we want this to actually be useful
+So, what information do we need to capture? If we're not saving locals or any
+heap memory, at a minimum, all we need is the `PC`(program counter) at each
+frame. This is just a raw address, though. If we want this to actually be useful
 we'll need to capture information that will allow us to symbolicate each `PC`
 into the actual function name/location.
 
-First we need to know which file contains the symbols we're using. Recall that a
-single Linux program can execute not only the code in main binary, but any
-dynamically linked code that might be used as well. To do this debuggers
+First, we need to know which file contains the symbols we're using. Recall that
+a single Linux program can execute not only the code in main binary but any
+dynamically linked code that might be used as well. To do this, debuggers
 typically use a combination of GNU build ID and path, so we'll need to capture
-both. Check out our previous articl on
+both. Check out our previous article on
 [GNU build IDs](https://interrupt.memfault.com/blog/gnu-build-id-for-firmware)
 for more info!
 
-An interesting wrinkle here though, is that address range present in the
-compiled binary and the address range used when the program is executing is
-different and random. This is a security feature of Linux called ASLR(Address
-Space Load Randomization)[^ASLR]. At a high level it randomizes the base address
-where the program is loaded into memory so that attackers cannot observe a
-program and attempt to intercept program execution by changing values on the
-stack. Therefore, to be able to decode addresses properly, we will need the PC
-range in addition to the compile time and run time offset.
+An interesting wrinkle here is that the address range present in the compiled
+binary and the address range used when the program is executing is different and
+random. This is a security feature of Linux called ASLR(Address Space Load
+Randomization)[^ASLR]. At a high level, it randomizes the base address where the
+program is loaded into memory so that attackers cannot observe a program and
+attempt to intercept program execution by changing values on the stack.
+Therefore, to decode addresses properly, we will need the PC range in addition
+to the compile time and run time offset.
 
 So we now have a minimal set of information we need to capture to get a complete
 backtrace:
@@ -116,25 +122,25 @@ An unwound stack can now be represented with the following JSON structure:
 }
 ```
 
-Using the above we can create our stacktrace by doing the following for each PC
+Using the above, we can create our stacktrace by doing the following for each PC
 in a thread:
 
 - Find the associated symbols by checking each `PC` range
-- Fetch the symbol file by by either build ID or path
+- Fetch the symbol file by either build ID or path
 - Shift the PC by subtracting the runtime offset and adding the compiled offset
-  to account for ASLR
+ to account for ASLR
 - Run the shifted address and associated symbol file through
   `addr2line`[^addr2line]
 
-After running through all of the above steps we should have a fully symbolicated
+After running through the above steps, we should have a fully symbolicated
 stacktrace for each thread in our program at the time of crash. Now that we know
-what our end goal is, how do we get all of this from a Linux core handler?
+our end goal, how do we get all of this from a Linux core handler?
 
 ## Understanding GNU Unwind Info
 
-To answer the above question, we need to take a look at how programs like GDB
+To answer the above question, we need to look at how programs like GDB
 and perf traverse the stack. The first thing to note is that there are actually
-two parts to backtrace creation. Obviously we need to convert raw address to
+two parts to backtrace creation. Obviously, we need to convert raw addresses to
 function names and local variable names, but we also need to know how each frame
 is constructed.
 
@@ -147,23 +153,22 @@ debugger, profiler, or any other program needs to know:
 Our first instinct is probably to reach to the frame pointer register. This, in
 theory, tells us where the previous frame starts, but there are a few problems
 here. For one, not every platform has a frame pointer. `x86-64` being the
-obvious example. Additionally some recent compilers have taken the step of
+obvious example. Additionally, some recent compilers have taken the step of
 turning the frame pointer register into a general purpose register as a
-performance improvement(TODO: ADD SOURCE). Even if we could depend on the frame
+performance improvement[^fomit]. Even if we could depend on the frame
 pointer, how do we know where the registers are relative to it?
 
-Luckily, there is a builtin mechanism provided by modern compilers to solve all
+Luckily, modern compilers have a built-in mechanism to solve all
 these problems! The `.eh_frame`[^eh_frame] section and its sibling the
-`.eh_frame_hdr`[^eh_frame_hdr] section together give us the ability get the
-structure the previous frame when providing the current `PC` value. We'll dive
+`.eh_frame_hdr`[^eh_frame_hdr] section together gives us the ability to get the previous frame's structure when providing the current `PC` value. We'll dive
 deeper into the structure of these sections in a moment, but they satisfy both
-of the requirements we previously laid out. When handling a crash we can take
-the first `PC` and derive the structure of the previous frame, and repeat that
+of the requirements we previously laid out. When handling a crash, we can take
+the first `PC` and derive the structure of the previous frame, then repeat that
 process until we hit the bottom of the stack!
 
 ### `.eh_frame` Contents
 
-As mentioned above, the `.eh_frame`[^.eh_frame] is a an ELF section included in
+As mentioned above, the `.eh_frame`[^.eh_frame] is an ELF section included in
 most programs compiled with a modern compiler. It contains a list of rules that
 allow us to rebuild the frame info that is implicitly encoded into the generated
 assembly of our program. These rules are called Call Frame Information (CFI)
@@ -171,6 +176,7 @@ records, and there is at least one per `.eh_frame`.
 
 Let's use the trusty `readelf` utility to take a peek at the contents
 `.eh_frame`[^.eh_frame] section:
+
 
 ```bash
 $ readelf --debug-dump=frames memfaultd
@@ -213,16 +219,16 @@ Contents of the .eh_frame section:
 ```
 
 `FDE`, `CFI`, `CIE`, `CFA`, oh my! Are these the names of obscure government
-agencies? Let's peel this back layer by layer and try to get an understanding.
+agencies? Let's peel this back layer by layer and try to understand it.
 
-Let's take a look at he first three terms here: `CFI`, `CIE`, and `FDE`. All of
-these relate to the structure of each frame. The first term, `CFI`, expands out
-to Common Frame Information. These are the highest level of hiearchy and
-represent a grouping of multiple bits of frame information. Every CFI will
-contain one or more `CIE` and `FDE`.
+Let's look at the first three terms here: `CFI`, `CIE`, and `FDE`. All of these
+relate to the structure of each frame. The first term, `CFI`, expands to Common
+Frame Information. The CFI represents a grouping of multiple bits of frame
+information and is at the highest level of the information hierarchy. Every CFI
+will contain one or more `CIE` and `FDE`.
 
 Peeling back one more layer, we can start to look at the `CIE` and `FDE`. `CIE`
-is an acronym for Common Information Entry, and represents a shared set of
+is an acronym for Common Information Entry and represents a shared set of
 instructions that can be used by any `FDE` in a given `CFI`. Let's take a gander
 at the `CIE` in our above example.
 
@@ -243,18 +249,18 @@ at the `CIE` in our above example.
 ```
 
 We're not going to cover everything here, but there are a few interesting bits
-to note. First this is `CIE` entry 0, noted by the preceding 0s before the `CIE`
-marker. This will be interesting later as we look at how `FDE`s relate to `CIE`.
-Next we see some version and alignment information. For our purposes, let's skip
+to note. First, this is `CIE` entry 0, noted by the preceding 0s before the `CIE`
+marker. This will be interesting later as we look at how `FDE`'s relate to `CIE`.
+Next, we see some version and alignment information. For our purposes, let's skip
 over those few lines and get to the meat of this ELF. We see a few lines
 starting with `DW_*`. These lines tell us information about how we can find our
 registers, as well as our `CFA`. We're finally starting to see how we can
-fulfill one of our earlier requirements, namely, how we find the register
+fulfill one of our earlier requirements: finding the register
 locations on each stack.
 
-We're about 3 acronyms deep now, only 20-30 left to get through! Next up is the
+We're about three acronyms deep now, only 20-30 left to get through! Next up is the
 `FDE` we've mentioned 4-5 times now. `FDE` stands for Frame Description Entry.
-It is similar to the `CIE`, but more specific in that it represents all
+It is similar to the `CIE` but more specific in that it represents all
 instructions needed to recreate a frame's structure. Let's comb through an `FDE`
 to get a better understanding.
 
@@ -271,12 +277,12 @@ to get a better understanding.
 ```
 
 Stepping through this bit by bit, we can see that we're using `CIE` 0 that we
-just took a look at. The next, bit of interesting information the `PC` range.
-Each `PC` range here represents the range of possible `PC` for a whole function.
-This is important, as the function that you're in dictates how registers are
-pushed onto the stack. If you don't touch any of them in the current function,
-the previous would not need to be saved! After that we have the same
-instructions we previously saw in our `CIE`. Note that our total set of
+just took a look at. The next bit of interesting information is the `PC` range.
+Each `PC` range here represents the range of possible `PC`s for a whole
+function. This is important, as the function that you're in dictates how
+registers are pushed onto the stack. If you don't touch any of them in the
+current function, the previous would not need to be saved! After that, we have
+the same instructions we previously saw in our `CIE`. Note that our total set of
 instructions are the ones present in the `CIE` in addition to those defined in
 the `FDE`.
 
@@ -284,16 +290,16 @@ the `FDE`.
 
 Alright, we're almost done defining acronyms, I promise! You may have noticed
 `CFA` mentioned in all of our unwind rules defined in both the `CIE` and `FDE`.
-`CFA` stands for Canonical Frame Address, and is probably the most important
-part of our unwind rules. It represents that base address of the frame we're
-trying to reconstruct. Looking out our `CIE` again you may recall this line:
+`CFA` stands for Canonical Frame Address and is probably the most important part
+of our unwind rules. It represents the base address of the frame we're trying to
+reconstruct. Looking out our `CIE` again, you may recall this line:
 
 ```bash
 DW_CFA_def_cfa: r7 (rsp) ofs 8
 ```
 
 This tells us that our `CFA` is equal to the `rsp`(x86-64 stack pointer) + 8.
-Neat! A picture may be starting to form in your mind; we're hand crafting a
+Neat! A picture may be starting to form in your mind; we're hand-crafting a
 stack frame! Artisanal! Compiler to table! Let's decode the next line in our
 `CIE` to understand how we can get individual registers.
 
@@ -308,27 +314,27 @@ this can be seen below:
 ![]({% img_url linux-coredump-3/x86-stack.png %})
 
 This acts as a kind of base case that we'll build rules on top of for our future
-FDEs. Here's what that unwind rules look like in a more general sense.
+FDEs. Here's what those unwind rules look like in a more general sense.
 
 ![]({% img_url linux-coredump-3/general_stack.png %})
 
-Since I've already been trying my hardest to make you stop reading I won't do
+Since I've already been trying my hardest to make you stop reading, I won't do
 anymore of these individual register unwinds, but you can see the pattern we
 have to follow and how we can reconstruct the frame from the information
-provided. If you want to read more on the different types of frame rules check
-out the `DWARF` spec[^dwarf].
+provided. If you want to read more about the different types of frame rules,
+check out the `DWARF` spec[^dwarf].
 
 We now know how to build our frame. Let's see how we hook this up to the Linux
-core handler to unwind our stack on device.
+core handler to unwind our stack on-device.
 
 ## Grabbing the Current Thread Info
 
-After diving through the above, we know how we're going to unwind the stack, but
-we need to grab a few other things as well. If you recall from earlier, there
-are two other inputs we need for our stacktrace. We need the current state of
-our general purpose registers, as well information to help our
-debugger/`addr2line`. Let's take a look first at how we'll get the state of the
-general purpose registers for each thread.
+After diving through the above, we know how we will unwind the stack, but we
+need to grab a few other things as well. If you recall from earlier, there are
+two other inputs we need for our stacktrace. We need the current state of our
+general purpose registers, as well information to help our debugger/`addr2line`.
+Let's take a look first at how we'll get the state of the general purpose
+registers for each thread.
 
 In [our previous
 article]({% link _posts/2025-05-02-linux-coredumps-part-2.md %}) we touched a
@@ -366,15 +372,15 @@ general purpose registers at the time of crash for each thread!
 
 After extracting the state of the GP registers from the note defined above, we
 can now use that as the starting point for the unwind logic mentioned above. One
-question remains open though. How do we get a mapping of main binary and dynamic
+question remains open, though. How do we get a mapping of main binary and dynamic
 libs to grab both our unwind info, as well as all the rendezvous information our
 debugger needs?
 
 ## Mapping Our Way to Stacks
 
-We now need to grab the following info; what binaries and dynamic libs are
-loaded by the program that is crashing, and what are their build IDs and and
-paths. In our previous articles we talked about taking advantage of the fact
+We now need to grab the following info: what binaries and dynamic libs are
+loaded by the program that is crashing, and what are their build IDs and
+paths. In our previous articles, we talked about taking advantage of the fact
 that `procfs` is still mounted for a `PID` that is currently dumping into a pipe
 core handler. We'll do that again here by looking at
 `/proc/<pid>/maps`[^proc_pid_maps]!
@@ -398,13 +404,13 @@ b6d0f000-b6d10000 rw-p 0006f000 b3:02 3494       /usr/lib/libzstd.so.1.5.2
 There is a ton of good information here! First looking at the address range,
 this gives us the runtime address we need to calculate our ASLR shift!
 
-A bit to the right we see the permission flags for each mapped segment. These
-are useful because we want to find the range in which our executable is mounted
-to know when we should look at the `.eh_frame` info for that particular binary.
-Since we're looking for the executable we need to grab the range and path for a
-memory map with the `x` permission.
+To the right of the address range, we see the permission flags for each mapped
+segment. These are useful because we want to find the range in which our
+executable is mounted to know when we should look at the `.eh_frame` info for
+that particular binary. Since we're looking for the executable, we need to grab
+the range and path for a memory map with the `x` permission.
 
-Now that we have the binary path we can grab our unwind infrom from the
+Now that we have the binary path, we can grab our unwind information from the
 `.eh_frame`/`.eh_frame_hdr` sections, as well as our GNU build ID from the
 `.note.gnu.build-id`.
 
@@ -412,12 +418,12 @@ Now that we have the binary path we can grab our unwind infrom from the
 
 We're almost there, let's run through what we have:
 
-- :white_check_mark: GP registers from `prstatus` note
-- :white_check_mark: binary/dynamic lib address range
-- :white_check_mark: runtime offset
-- :white_check_mark: binary path
-- :white_check_mark: `.eh_frame`/`.eh_frame_hdr` sections from each binary
-- :white_check_mark: Build ID from `.note.gnu.build-id`
+- ☑️ GP registers from `prstatus` note
+- ☑️ binary/dynamic lib address range
+- ☑️ runtime offset
+- ☑️ binary path
+- ☑️ `.eh_frame`/`.eh_frame_hdr` sections from each binary
+- ☑️ Build ID from `.note.gnu.build-id`
 
 Let's look at a full example generated from a crash caused by
 `memfaultctl trigger-coredump`[^memfaultctl_coredump]:
@@ -464,8 +470,8 @@ Let's look at a full example generated from a crash caused by
 }
 ```
 
-Starting at the top of our stack we see this address: `0x55ea82cff77c`. If we
-look at the address range for `memfaultd` we see the following:
+Starting at the top of our stack, we see this address: `0x55ea82cff77c`. If we
+look at the address range for `memfaultd`, we see the following:
 
 ```json
 "pc_range": {
@@ -474,8 +480,8 @@ look at the address range for `memfaultd` we see the following:
 },
 ```
 
-Our address of `0x55ea82cff77c` fits in this range, so we know that it's in that
-binary. To be able to feed this into `addr2line`[^addr2line] we need to first
+Our address of `0x55ea82cff77c` fits in this range, so we know it's in that
+binary. To be able to feed this into `addr2line`[^addr2line], we need to first
 account for our ASLR[^ASLR] shift. Note these members of our stacktrace:
 
 ```json
@@ -485,7 +491,7 @@ account for our ASLR[^ASLR] shift. Note these members of our stacktrace:
 
 `addr2line`[^addr2line] expects the address fed into it in the address space of
 the compiled binary. This means we need to perform the following bit of math:
-`address - runtime_offset + compiled_offset`. After applying that equation we
+`address - runtime_offset + compiled_offset`. After applying that equation, we
 get `1f877c`.
 
 ```bash
@@ -495,32 +501,32 @@ core::ptr::write
 ```
 
 From the above you can see we're in the suspect line that caused our crash! Just
-as expected it's a NULL pointer write! To get the full stacktrace the above
+as expected, it's a NULL pointer write! To get the full stacktrace, the above
 process will be repeated for each function in the call stack!
 
 ## Conclusion
 
 We made it! We got through the densest wall of acryonyms ever created, and
-arrived at a method of capturing crashes on device that preserves privacy of end
-users while also shrinking size requirements considerably.
+arrived at a method of capturing crashes on-device that preserves the privacy of
+end users while also shrinking size requirements considerably.
 
 Let's recap what we've learned in this series of articles.
 
 In [Part 1]({% link _posts/2025-02-14-linux-coredumps-part-1.md %}) we covered
-the basics for how Linux coredumps work. This set the stage for the rest of our
+the basics of how Linux coredumps work. This set the stage for the rest of our
 articles as we learned about the general structure of an ELF core file.
 
-In [Part 2]({% link _posts/2025-05-02-linux-coredumps-part-2.md %}) we tackled
+In [Part 2]({% link _posts/2025-05-02-linux-coredumps-part-2.md %}), we tackled
 one of the biggest problems we see with coredumps in Linux, the size. Using
-information from the coredump itself we captured only the stacks while
+information from the coredump itself, we captured only the stacks while
 discarding all heap values.
 
 Finally, in this article, we addressed another problem, privacy. Coredumps can
-potentially contain customer data, after all they are just snapshots of memory.
+potentially contain customer data; after all, they are just snapshots of memory.
 Our final implementation gets rid of all stack and heap memory. The downside
 here is that we no longer get to inspect local variables. For most crashes this
 is an acceptable tradeoff. If you'd like to dive deeper into the full
-implementation of the on-device unwinding you can find it
+implementation of the on-device unwinding, you can find it
 [here](https://github.com/memfault/memfaultd/tree/main/memfaultd/src/cli/memfault_core_handler/stack_unwinder).
 
 <!-- Interrupt Keep START -->
@@ -538,6 +544,7 @@ implementation of the on-device unwinding you can find it
 <!-- prettier-ignore-start -->
 [^ASLR]: [`ASLR`](https://en.wikipedia.org/wiki/Address_space_layout_randomization)
 [^addr2line]: [`addr2line`](https://linux.die.net/man/1/addr2line)
+[^fomit]: [`-fomit`](https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html#index-fomit-frame-pointer)
 [^eh_frame]: [`.eh_frame`](https://refspecs.linuxfoundation.org/LSB_3.0.0/LSB-Core-generic/LSB-Core-generic/ehframechpt.html)
 [^eh_frame_hdr]: [`.eh_frame_hdr`](https://refspecs.linuxfoundation.org/LSB_1.3.0/gLSB/gLSB/ehframehdr.html)
 [^proc_pid_maps]: [`proc_pid_maps`](https://man7.org/linux/man-pages/man5/proc_pid_maps.5.html)

--- a/_posts/2025-06-20-linux-coredumps-part-3.md
+++ b/_posts/2025-06-20-linux-coredumps-part-3.md
@@ -22,7 +22,7 @@ the size needed to store them.
 <!-- excerpt end -->
 
 By unwinding the stack locally on the device, we don't need to push any sections
-of memory out to another device/server and can just push the PC of each frame to
+of memory out to another device/server and can just push the `PC` of each frame to
 be symbolicated separately. In this post, we'll cover the mechanism by which
 programs compiled with GCC/LLVM handle stack unwinding, and how we can leverage
 that to do local stack unwinding.


### PR DESCRIPTION
### Summary

 This is the final part of our series on Linux coredumps! Notable
 changes from the draft:

 - Grammar/format fixes
 - Added callout for Blake's talk next week
 - Add extra footnote

 ### Test Plan

 - [x] Run through publishing checklist