### PR TITLE
chore: remove conference talk blurb in linux coredumps series

### DIFF
--- a/_posts/2025-02-14-linux-coredumps-part-1.md
+++ b/_posts/2025-02-14-linux-coredumps-part-1.md
@@ -22,11 +22,10 @@ formatted, how you capture them, and how we use them at Memfault.
 
 <!-- excerpt end -->
 
-> 📢 If you're attending Open Source Summit North America 2025, don’t miss
-> Blake's talk,
-> ["Efficient On-Device Core Dump Processing for IoT: A Rusty Implementation,"](https://sched.co/1zfib)
-> on Tuesday, June 24th at 9:00am MDT in Bluebird Ballroom 2B. He’ll dive even
-> deeper into the techniques explored in this series.
+<!-- TODO: Update with recording link when available -->
+<!-- > Listen to a recording of Blake's talk from Open Source Summit North America 2025,
+> ["Efficient On-Device Core Dump Processing for IoT: A Rusty Implementation,"](UPDATE)
+> for an even deeper diver into the techniques explored in this series. -->
 
 {% include newsletter.html %}
 
@@ -323,11 +322,12 @@ the hood. While the baseline coredumps are useful and a known commodity, there
 are a few things that aren't great about them. The biggest issue is that they
 can be quite large for processes with many threads or do a large amount of
 memory allocation. This can be a significant problem for embedded devices that
-may not have a lot of room to store large files. In the [next article]({% link _posts/2025-05-02-linux-coredumps-part-2.md %}), we take
-a look at the steps we've taken to reduce the size of coredumps.
+may not have a lot of room to store large files. In the [next
+article]({% link _posts/2025-05-02-linux-coredumps-part-2.md %}), we take a look
+at the steps we've taken to reduce the size of coredumps.
 
-If you'd like to poke around the source code for the coredump
-handler, you can find it
+If you'd like to poke around the source code for the coredump handler, you can
+find it
 [here](https://github.com/memfault/memfaultd/tree/main/memfaultd/src/cli/memfault_core_handler).
 
 <!-- Interrupt Keep START -->

--- a/_posts/2025-05-02-linux-coredumps-part-2.md
+++ b/_posts/2025-05-02-linux-coredumps-part-2.md
@@ -23,11 +23,10 @@ critical debugging information.
 
 <!-- excerpt end -->
 
-> 📢 If you're attending Open Source Summit North America 2025, don’t miss
-> Blake's talk,
-> ["Efficient On-Device Core Dump Processing for IoT: A Rusty Implementation,"](https://sched.co/1zfib)
-> on Tuesday, June 24th at 9:00am MDT in Bluebird Ballroom 2B. He’ll dive even
-> deeper into the techniques explored in this series.
+<!-- TODO: Update with recording link when available -->
+<!-- > Listen to a recording of Blake's talk from Open Source Summit North America 2025,
+> ["Efficient On-Device Core Dump Processing for IoT: A Rusty Implementation,"](UPDATE)
+> for an even deeper diver into the techniques explored in this series. -->
 
 {% include newsletter.html %}
 

--- a/_posts/2025-06-20-linux-coredumps-part-3.md
+++ b/_posts/2025-06-20-linux-coredumps-part-3.md
@@ -22,16 +22,15 @@ the size needed to store them.
 <!-- excerpt end -->
 
 By unwinding the stack locally on the device, we don't need to push any sections
-of memory out to another device/server and can just push the `PC` of each frame to
-be symbolicated separately. In this post, we'll cover the mechanism by which
+of memory out to another device/server and can just push the `PC` of each frame
+to be symbolicated separately. In this post, we'll cover the mechanism by which
 programs compiled with GCC/LLVM handle stack unwinding, and how we can leverage
 that to do local stack unwinding.
 
-> 📢 If you're attending Open Source Summit North America 2025, don’t miss
-> Blake's talk,
-> ["Efficient On-Device Core Dump Processing for IoT: A Rusty Implementation,"](https://sched.co/1zfib)
-> on Tuesday, June 24th at 9:00am MDT in Bluebird Ballroom 2B. He’ll dive even
-> deeper into the techniques explored in this series.
+<!-- TODO: Update with recording link when available -->
+<!-- > Listen to a recording of Blake's talk from Open Source Summit North America 2025,
+> ["Efficient On-Device Core Dump Processing for IoT: A Rusty Implementation,"](UPDATE)
+> for an even deeper diver into the techniques explored in this series. -->
 
 {% include newsletter.html %}
 
@@ -140,11 +139,11 @@ our end goal, how do we get all of this from a Linux core handler?
 
 ## Understanding GNU Unwind Info
 
-To answer the above question, we need to look at how programs like GDB and `perf`
-traverse the stack. The first thing to note is that there are actually two parts
-to backtrace creation. Obviously, we need to convert raw addresses to function
-names and local variable names, but we also need to know how each frame is
-constructed.
+To answer the above question, we need to look at how programs like GDB and
+`perf` traverse the stack. The first thing to note is that there are actually
+two parts to backtrace creation. Obviously, we need to convert raw addresses to
+function names and local variable names, but we also need to know how each frame
+is constructed.
 
 When unwinding a stack, there is information about the previous frame that a
 debugger, profiler, or any other program needs to know:


### PR DESCRIPTION
### Summary

 Remove the talk blurb now that the talk has happened. The blurb now
 refers to a recording, but the recordings are not yet available. Comment
 it out for now while we wait for the recordings to be published.