### PR TITLE
chore: add talk recording link to Linux coredump series

### DIFF
--- a/_posts/2025-02-14-linux-coredumps-part-1.md
+++ b/_posts/2025-02-14-linux-coredumps-part-1.md
@@ -22,10 +22,10 @@ formatted, how you capture them, and how we use them at Memfault.
 
 <!-- excerpt end -->
 
-<!-- TODO: Update with recording link when available -->
-<!-- > Listen to a recording of Blake's talk from Open Source Summit North America 2025,
-> ["Efficient On-Device Core Dump Processing for IoT: A Rusty Implementation,"](UPDATE)
-> for an even deeper diver into the techniques explored in this series. -->
+> 🎥 Listen to a recording of Blake's talk from Open Source Summit North America
+> 2025,
+> ["Efficient On-Device Core Dump Processing for IoT: A Rusty Implementation,"](https://www.youtube.com/watch?v=fDwDXg7T4K8)
+> for an even deeper diver into the techniques explored in this series.
 
 {% include newsletter.html %}
 

--- a/_posts/2025-05-02-linux-coredumps-part-2.md
+++ b/_posts/2025-05-02-linux-coredumps-part-2.md
@@ -23,10 +23,10 @@ critical debugging information.
 
 <!-- excerpt end -->
 
-<!-- TODO: Update with recording link when available -->
-<!-- > Listen to a recording of Blake's talk from Open Source Summit North America 2025,
-> ["Efficient On-Device Core Dump Processing for IoT: A Rusty Implementation,"](UPDATE)
-> for an even deeper diver into the techniques explored in this series. -->
+> 🎥 Listen to a recording of Blake's talk from Open Source Summit North America
+> 2025,
+> ["Efficient On-Device Core Dump Processing for IoT: A Rusty Implementation,"](https://www.youtube.com/watch?v=fDwDXg7T4K8)
+> for an even deeper diver into the techniques explored in this series.
 
 {% include newsletter.html %}
 

--- a/_posts/2025-06-20-linux-coredumps-part-3.md
+++ b/_posts/2025-06-20-linux-coredumps-part-3.md
@@ -27,10 +27,10 @@ to be symbolicated separately. In this post, we'll cover the mechanism by which
 programs compiled with GCC/LLVM handle stack unwinding, and how we can leverage
 that to do local stack unwinding.
 
-<!-- TODO: Update with recording link when available -->
-<!-- > Listen to a recording of Blake's talk from Open Source Summit North America 2025,
-> ["Efficient On-Device Core Dump Processing for IoT: A Rusty Implementation,"](UPDATE)
-> for an even deeper diver into the techniques explored in this series. -->
+> 🎥 Listen to a recording of Blake's talk from Open Source Summit North America
+> 2025,
+> ["Efficient On-Device Core Dump Processing for IoT: A Rusty Implementation,"](https://www.youtube.com/watch?v=fDwDXg7T4K8)
+> for an even deeper diver into the techniques explored in this series.
 
 {% include newsletter.html %}
 


### PR DESCRIPTION
 ### Summary

Recordings from EOSS are now available! Add the link to a the coredump talk
associated with the linux coredump series.

### Test Plan

- [x] Check links