### PR TITLE
Update 2025-07-03-june-2025-roundup.md

### DIFF
--- a/_posts/2025-07-03-june-2025-roundup.md
+++ b/_posts/2025-07-03-june-2025-roundup.md
@@ -84,7 +84,7 @@ What have you been reading? Share in the comments or
   observability really means for AI at the edge. Catch it live at 8am PT | 11am
   ET | 5pm CET.
 
-- [**Tuesday, August 24 – _RESCHEDULED_ Coredump EP #015: Developing Kid-Safe Tech at Gabb: What It Takes and Why It’s So Important**](https://memfault.com/resources/developing-kid-safe-tech-at-gabb-what-it-takes-and-why-its-so-important/)<br>
+- [**Tuesday, August 19 – _RESCHEDULED_ Coredump EP #015: Developing Kid-Safe Tech at Gabb: What It Takes and Why It’s So Important**](https://memfault.com/resources/developing-kid-safe-tech-at-gabb-what-it-takes-and-why-its-so-important/)<br>
   When you're building tech for kids, reliability isn’t negotiable. Devices need
   to be always-on, always-connected, and dead-simple to use. Gabb’s engineering
   team joins Memfault to share how they tackle power constraints, OTA updates,


### PR DESCRIPTION
Fixed typo in title of last event: Date is August 19, not August 24 (it was rescheduled from June 24, that's how the old date got stuck in there).