### PR TITLE
feat(mad): add top posts section to homepage and aside

### DIFF
--- a/_data/top_posts.yml
+++ b/_data/top_posts.yml
@@ -1,0 +1,14 @@
+# Top Posts List
+# Add post filenames here (without .md extension) to mark them as top posts
+# Ordered by publication date (oldest to newest)
+posts:
+  - "2019-07-09-get-the-most-out-of-the-linker-map-file"
+  - "2019-08-13-how-to-write-a-bootloader-from-scratch"
+  - "2019-09-04-arm-cortex-m-exceptions-and-nvic"
+  - "2019-10-08-unit-testing-basics"
+  - "2019-10-22-best-and-worst-gcc-clang-compiler-flags"
+  - "2019-10-30-cortex-m-rtos-context-switching"
+  - "2019-11-20-cortex-m-hardfault-debug"
+  - "2020-02-18-firmware-watchdog-best-practices"
+  - "2020-03-23-intro-to-renode"
+  - "2023-08-09-a-modern-c-dev-env"

--- a/_includes/by-memfault.html
+++ b/_includes/by-memfault.html
@@ -1,0 +1,11 @@
+<div class="memfault-info-wrapper">
+  <p>
+      <img class="mf-icon" src="{% img_url memfault-logo.png %}" />
+      Brought to you with <span style="font-size: 10px;">❤️</span> by Memfault.
+      <br/>
+      <a href="https://memfault.com/">
+          Learn more
+          <img class="chevron-icon" src="{% img_url chevron-right.svg %}" />
+      </a>
+  </p>
+</div>

--- a/_includes/posts-nav.html
+++ b/_includes/posts-nav.html
@@ -1,0 +1,21 @@
+<div class="memfault-info-wrapper">
+  <h3 class="">Latest Blog Posts</h3>
+  <p>See the latest content from the Interrupt community.</p>
+      <p>
+        <a href="{{ '/' | relative_url }}#latest-blog-posts">
+          View latest blog posts
+          <img class="chevron-icon" src="{% img_url chevron-right.svg %}" />
+        </a>
+    </p>
+</div>
+
+<div class="memfault-info-wrapper">
+  <h3 class="">Top Blog Posts</h3>
+  <p>Read the posts that readers love the most.</p>
+      <p>
+        <a href="{{ '/' | relative_url }}#top-blog-posts">
+          View top blog posts
+          <img class="chevron-icon" src="{% img_url chevron-right.svg %}" />
+        </a>
+    </p>
+</div>

--- a/_includes/share-buttons.html
+++ b/_includes/share-buttons.html
@@ -10,44 +10,6 @@
     {% assign pagetitle = page.title | url_encode %}
 {% endif %}
 
-<div class="memfault-info-wrapper">
-    <h3 class="">Embedded Events</h3>
-    <p>Discover embedded events online and around the world or share your own.</p>
-    {% for event in site.data.featured_events.events %}
-        <p>
-            <a href="{{ event.link }}">{{ event.name }}</a>
-        </p>
-    {% endfor %}
-    <p>
-        <a href="{{ '/events' | relative_url }}">
-            View all events
-        <img class="chevron-icon" src="{% img_url chevron-right.svg %}" />
-        </a>
-    </p>
-</div>
-
-<div class="memfault-info-wrapper">
-    <h3 class="">Sandbox Demo</h3>
-    <p>Explore Memfault firsthand with real data, guided product tours, and no SDK integration needed!</p>
-    <p>
-        <a href="https://demo.memfault.com/demo/start?utm_campaign=Sandbox&utm_source=Interrupt&utm_medium=side%20bar">
-            Try the Sandbox
-            <img class="chevron-icon" src="/img/chevron-right.svg">
-        </a>
-    </p>
-</div>
-
-<div class="memfault-info-wrapper">
-    <p>
-        <img class="mf-icon" src="{% img_url memfault-logo.png %}" />
-        Brought to you with <span style="font-size: 10px;">❤️</span> by Memfault.
-        <br/>
-        <a href="https://memfault.com/">
-            Learn more
-            <img class="chevron-icon" src="{% img_url chevron-right.svg %}" />
-        </a>
-    </p>
-</div>
 <div class="share-buttons-wrapper">
     <h3>Share on: </h3>
     <div id="share-buttons">

--- a/_layouts/homepage.html
+++ b/_layouts/homepage.html
@@ -34,6 +34,8 @@
 				<aside>
 					{% include search.html %}
 					{% include subscribe.html %}
+					{% include posts-nav.html %}
+					{% include by-memfault.html %}
 					{% include share-buttons.html %}
 				</aside>
 			</div>

--- a/_layouts/split-view.html
+++ b/_layouts/split-view.html
@@ -31,6 +31,8 @@
         <aside>
           {% include search.html %}
           {% include subscribe.html %}
+          {% include posts-nav.html %}
+          {% include by-memfault.html %}
           {% include share-buttons.html %}
         </aside>
       </div>

--- a/index.html
+++ b/index.html
@@ -110,8 +110,8 @@ layout: homepage
         </li>
     </ul>
 
-    <h2 class="home-header-2">
-        <a href="{{ '/blog' | relative_url }}">
+    <h2 class="home-header-2" id="latest-blog-posts">
+        <a href="{{ '/' | relative_url }}#latest-blog-posts">
             Latest Blog Posts
         </a>
     </h2>
@@ -122,6 +122,13 @@ layout: homepage
 
         {% for post in posts %}
             <li class="post">
+                {% if post.image and post.image != '/img/interrupt-cover-1200px.png' %}
+                <div class="post-image">
+                    <a href="{{ post.url | relative_url }}">
+                        <img src="{{ post.image | relative_url }}" alt="{{ post.title }}">
+                    </a>
+                </div>
+                {% endif %}
                 <h2><a href="{{ post.url | relative_url }}">{{ post.title }}</a></h2>
                 <div class="by-line">
                     <time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date_to_string }}</time>
@@ -147,13 +154,55 @@ layout: homepage
         <img class="chevron-icon" src="{% img_url chevron-right-white.svg %}" />
     </a>
 
-    <h2 class="home-header-2">
+        <h2 class="home-header-2" id="top-blog-posts">
+        <a href="{{ '/' | relative_url }}#top-blog-posts">
+            Top Blog Posts
+        </a>
+    </h2>
+    <ul id="posts">
+        {% assign top_posts = "" | split: "" %}
+        {% for post in site.posts %}
+            {% assign post_filename = post.path | split: "/" | last | split: "." | first %}
+            {% if site.data.top_posts.posts contains post_filename %}
+                {% assign top_posts = top_posts | push: post %}
+            {% endif %}
+        {% endfor %}
+        {% assign top_posts = top_posts | limit: 6 %}
+        {% for post in top_posts %}
+            <li class="post">
+                {% if post.image and post.image != '/img/interrupt-cover-1200px.png' %}
+                <div class="post-image">
+                    <a href="{{ post.url | relative_url }}">
+                        <img src="{{ post.image | relative_url }}" alt="{{ post.title }}">
+                    </a>
+                </div>
+                {% endif %}
+                <h2><a href="{{ post.url | relative_url }}">{{ post.title }}</a></h2>
+                <div class="by-line">
+                    <time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date_to_string }}</time>
+                    {% assign author = site.data.authors[post.author] %}
+                    {% assign author_key = post.author %}
+                    {% if author %}
+                        <span>by <a href="{{ '/authors/' | append:author_key | relative_url }}">{{ author.name }}</a></span>
+                    {% endif %}
+                </div>
+                <p>{{ post.excerpt }}</p>
+            </li>
+        {% endfor %}
+    </ul>
+
+    <a href="{{ '/blog' | relative_url }}" class="home-show-more">
+        View all posts
+        <img class="chevron-icon" src="{% img_url chevron-right-white.svg %}" />
+    </a>
+
+    <h2 class="home-header-2" id="about-memfault">
         About Memfault
     </h2>
     <p>
         Memfault is the first cloud-based observability platform for connected device debugging, monitoring, and updating, which brings the efficiencies and innovation of software development to hardware processes. Recognizing that any connected device team could benefit from what they were building, François Baldassari, Chris Coleman, and Tyler Hoffman founded Memfault in 2018 with the help of colleagues from Pebble.
-        <a href="https://memfault.com/signup">
-            Try Memfault
+        <a href="https://demo.memfault.com/demo/start?utm_campaign=Sandbox&utm_source=Interrupt&utm_medium=side%20bar">
+            Explore Memfault
             <svg class="svg-icon slack">
                 <use xlink:href="{% img_url main-icons.svg#arrow-right %}"></use>
             </svg>


### PR DESCRIPTION
### Summary

 Readers can now see the most popular posts on the homepage. Additionally,
 navigation is now available in the sidebar to jump to the latest or
 top posts. A few changes accompanied this feature:
 - Remove events and sandbox demo from sidebar to make room for new nav
 - Replace Try Memfault with Explore Memfault in the footer "About Memfault"
   with a link to the sandbox. Most readers are more likely to look at
   the sandbox than fill out a form
- Add "by memfault" section to the aside in the post page

Improvements for the future:
 - Add more cover images for posts -- you'll notice that some of the
 older popular posts have them and they look awesome!
 - Make a separate page for top posts. Currently this only exisits on the
 homepage
 - Scrape cloudflare dynamically for top posts instead of the current static list

### Test Plan

- [x] Check blog links in new Top Posts section work
- [x] Check links in aside work in homepage
- [x] Check links in aside work in post page