### PR TITLE
fix: give SVG images a white background in dark mode

### DIFF
--- a/_sass/modules/_dark-mode.scss
+++ b/_sass/modules/_dark-mode.scss
@@ -142,6 +142,15 @@
     border-radius: 4px;
     padding: 2px;
   }
+
+  // SVG diagrams commonly have dark text on transparent backgrounds, which
+  // becomes invisible against the dark page background. Give them a white
+  // backdrop. Targets only SVGs (diagrams), not photos (jpg/png).
+  article .content img[src$=".svg"] {
+    background-color: white;
+    border-radius: 4px;
+    padding: 4px;
+  }
 }
 
 // System preference: apply dark theme only when no explicit choice is saved.


### PR DESCRIPTION
We recently introduced dark mode. SVG images often have dark text on transparent backgrounds, making them invisible when the page background is dark.

As a workaround, add a white backdrop via CSS on SVGs (by file extension). There may be better fixes here, but this works well in my testing and requires no action from contributors (e.g. multiple images).

Before/after:
<img width="913" height="427" alt="image" src="https://github.com/user-attachments/assets/9fd6fbf5-c609-45f8-a8a8-581e2889b651" />
<img width="913" height="427" alt="image" src="https://github.com/user-attachments/assets/97bd46ba-2d02-4b05-9dd2-56e021040245" />